### PR TITLE
Create consistent hashing library based on a published paper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bazel-bin
+bazel-out
+bazel-testlogs
+bazel-virtual-people-core-serving

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,8 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "com_google_googletest",
+    urls = ["https://github.com/google/googletest/archive/release-1.10.0.tar.gz"],
+    sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
+    strip_prefix = "googletest-release-1.10.0",
+)

--- a/src/main/cc/wfa/virtual_people/core/model/utils/BUILD.bazel
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//src:__subpackages__"])
+
+_INCLUDE_PREFIX = "/src/main/cc"
+
+cc_library(
+    name = "consistent_hash",
+    srcs = ["consistent_hash.cc"],
+    hdrs = ["consistent_hash.h"],
+    strip_include_prefix = _INCLUDE_PREFIX,
+)
+
+cc_test(
+    name = "consistent_hash_test",
+    srcs = ["consistent_hash_test.cc"],
+    deps = [
+        ":consistent_hash",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.cc
@@ -22,7 +22,7 @@ namespace wfa_virtual_people {
 // published paper:
 //   https://arxiv.org/pdf/1406.2294.pdf
 int32_t JumpConsistentHash(uint64_t key, int32_t num_buckets) {
-  int64_t b = 1, j = 0;
+  int64_t b = -1, j = 0;
   while (j < num_buckets) {
     b = j;
     key = key * 2862933555777941757ULL + 1;

--- a/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.cc
@@ -23,6 +23,7 @@ namespace wfa_virtual_people {
 //   https://arxiv.org/pdf/1406.2294.pdf
 int32_t JumpConsistentHash(uint64_t key, int32_t num_buckets) {
   int32_t b = -1;
+  // Use int64_t for j to handle int32_t overflow.
   for (int64_t j = 0; j < num_buckets; ) {
     b = j;
     key = key * 2862933555777941757ULL + 1;

--- a/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.cc
@@ -29,7 +29,7 @@ int32_t JumpConsistentHash(uint64_t key, int32_t num_buckets) {
     j = (b + 1) * (static_cast<double>(1LL << 31) /
                    static_cast<double>((key >> 33) + 1));
   }
-  return b;
+  return static_cast<int32_t>(b);
 }
 
 }  // namespace wfa_virtual_people

--- a/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.cc
@@ -1,0 +1,25 @@
+#include "wfa/virtual_people/core/model/utils/consistent_hash.h"
+
+#include <cstdint>
+
+namespace wfa_virtual_people {
+namespace core {
+namespace utils {
+
+// This implementation is a copy and formatting of Figure 1 on page 2 in the
+// published paper:
+//   https://arxiv.org/pdf/1406.2294.pdf
+int32_t JumpConsistentHash(uint64_t key, int32_t num_buckets) {
+  int64_t b = 1, j = 0;
+  while (j < num_buckets) {
+    b = j;
+    key = key * 2862933555777941757ULL + 1;
+    j = (b + 1) * (static_cast<double>(1LL << 31) /
+                   static_cast<double>((key >> 33) + 1));
+  }
+  return b;
+}
+
+}  // namespace utils
+}  // namespace core
+}  // namespace wfa_virtual_people

--- a/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.cc
@@ -1,10 +1,22 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "wfa/virtual_people/core/model/utils/consistent_hash.h"
 
 #include <cstdint>
 
 namespace wfa_virtual_people {
-namespace core {
-namespace utils {
 
 // This implementation is a copy and formatting of Figure 1 on page 2 in the
 // published paper:
@@ -20,6 +32,4 @@ int32_t JumpConsistentHash(uint64_t key, int32_t num_buckets) {
   return b;
 }
 
-}  // namespace utils
-}  // namespace core
 }  // namespace wfa_virtual_people

--- a/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.cc
@@ -22,14 +22,14 @@ namespace wfa_virtual_people {
 // published paper:
 //   https://arxiv.org/pdf/1406.2294.pdf
 int32_t JumpConsistentHash(uint64_t key, int32_t num_buckets) {
-  int64_t b = -1, j = 0;
-  while (j < num_buckets) {
+  int32_t b = -1;
+  for (int64_t j = 0; j < num_buckets; ) {
     b = j;
     key = key * 2862933555777941757ULL + 1;
-    j = (b + 1) * (static_cast<double>(1LL << 31) /
+    j = (j + 1) * (static_cast<double>(1LL << 31) /
                    static_cast<double>((key >> 33) + 1));
   }
-  return static_cast<int32_t>(b);
+  return b;
 }
 
 }  // namespace wfa_virtual_people

--- a/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.h
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.h
@@ -1,0 +1,36 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef WFA_VIRTUAL_PEOPLE_CORE_MODEL_UTILS_CONSISTENT_HASH_H_
+#define WFA_VIRTUAL_PEOPLE_CORE_MODEL_UTILS_CONSISTENT_HASH_H_
+
+#include <cstdint>
+
+namespace wfa_virtual_people {
+namespace core {
+namespace utils {
+
+// Applies consistent hashing, to map the input key to one of the buckets.
+// Each bucket is represented by an index with range [0, num_buckets - 1].
+// The output is the index of the selected bucket.
+//
+// The consistent hashing algorithm is from the published paper:
+//   https://arxiv.org/pdf/1406.2294.pdf
+int32_t JumpConsistentHash(uint64_t key, int32_t num_buckets);
+
+}  // namespace utils
+}  // namespace core
+}  // namespace wfa_virtual_people
+
+#endif  // WFA_VIRTUAL_PEOPLE_CORE_MODEL_UTILS_CONSISTENT_HASH_H_

--- a/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.h
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash.h
@@ -18,8 +18,6 @@
 #include <cstdint>
 
 namespace wfa_virtual_people {
-namespace core {
-namespace utils {
 
 // Applies consistent hashing, to map the input key to one of the buckets.
 // Each bucket is represented by an index with range [0, num_buckets - 1].
@@ -29,8 +27,6 @@ namespace utils {
 //   https://arxiv.org/pdf/1406.2294.pdf
 int32_t JumpConsistentHash(uint64_t key, int32_t num_buckets);
 
-}  // namespace utils
-}  // namespace core
 }  // namespace wfa_virtual_people
 
 #endif  // WFA_VIRTUAL_PEOPLE_CORE_MODEL_UTILS_CONSISTENT_HASH_H_

--- a/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash_test.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash_test.cc
@@ -1,0 +1,48 @@
+#include "wfa/virtual_people/core/model/utils/consistent_hash.h"
+
+#include <random>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace wfa_virtual_people {
+namespace core {
+namespace utils {
+namespace {
+
+using ::testing::AnyOf;
+
+constexpr int kKeyNumber = 1000;
+constexpr int32_t kMaxBuckets = 1 << 16;
+
+// When using the same key, for any number of buckets n > 1, one of the
+// following must be satisfied
+// * JumpConsistentHash(key, n) == JumpConsistentHash(key, n - 1)
+// * JumpConsistentHash(key, n) == n - 1
+void CheckCorrectnessForOneKey(const uint64_t key, const int32_t max_buckets) {
+  int32_t last_output = 0;
+  for (int32_t num_buckets = 1; num_buckets <= max_buckets; ++num_buckets) {
+    int32_t output = JumpConsistentHash(key, num_buckets);
+    EXPECT_THAT(output, AnyOf(last_output, num_buckets - 1))
+        << "with key " << key << " and max_buckets " << max_buckets;
+    last_output = output;
+  }
+}
+
+TEST(JumpConsistentHashTest, TestCorrectness) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<unsigned long long> distrib(
+      std::numeric_limits<std::uint64_t>::min(),
+      std::numeric_limits<std::uint64_t>::max()
+  );
+  for (int i = 0; i < kKeyNumber; i++) {
+    uint64_t key = static_cast<uint64_t>(distrib(gen));
+    CheckCorrectnessForOneKey(key, kMaxBuckets);
+  }
+}
+
+}  // namespace
+}  // namespace utils
+}  // namespace core
+}  // namespace wfa_virtual_people

--- a/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash_test.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash_test.cc
@@ -54,5 +54,20 @@ TEST(JumpConsistentHashTest, TestCorrectness) {
   }
 }
 
+TEST(JumpConsistentHashTest, TestIntMaxBuckets) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<unsigned long long> distrib(
+      std::numeric_limits<std::uint64_t>::min(),
+      std::numeric_limits<std::uint64_t>::max()
+  );
+  for (int i = 0; i < kKeyNumber; i++) {
+    uint64_t key = static_cast<uint64_t>(distrib(gen));
+    int32_t output =
+        JumpConsistentHash(key, std::numeric_limits<std::int32_t>::max());
+    EXPECT_GE(output, 0);
+  }
+}
+
 }  // namespace
 }  // namespace wfa_virtual_people

--- a/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash_test.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/consistent_hash_test.cc
@@ -1,3 +1,17 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "wfa/virtual_people/core/model/utils/consistent_hash.h"
 
 #include <random>
@@ -6,8 +20,6 @@
 #include "gtest/gtest.h"
 
 namespace wfa_virtual_people {
-namespace core {
-namespace utils {
 namespace {
 
 using ::testing::AnyOf;
@@ -43,6 +55,4 @@ TEST(JumpConsistentHashTest, TestCorrectness) {
 }
 
 }  // namespace
-}  // namespace utils
-}  // namespace core
 }  // namespace wfa_virtual_people


### PR DESCRIPTION
Add implementation of consistent hashing based on https://arxiv.org/pdf/1406.2294.pdf.

The impelmentation is copied and formatted from Figure 1 on page 2 in https://arxiv.org/pdf/1406.2294.pdf.