### PR TITLE
Fix style and format PopulationNodeImpl and VirtualPersonSelector library.

### DIFF
--- a/src/main/cc/wfa/virtual_people/core/model/BUILD.bazel
+++ b/src/main/cc/wfa/virtual_people/core/model/BUILD.bazel
@@ -18,13 +18,14 @@ cc_library(
     ],
     strip_include_prefix = _INCLUDE_PREFIX,
     deps = [
+        "//src/main/cc/wfa/virtual_people/core/model/utils:virtual_person_selector",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_farmhash//:farmhash",
+        "@cross_media_measurement//src/main/cc/wfa/measurement/common:macros",
         "@virtual_people_common//src/main/proto/wfa/virtual_people/common:model_cc_proto",
-        "//src/main/cc/wfa/virtual_people/core/model/utils:virtual_person_selector",
     ],
 )
 
@@ -36,6 +37,8 @@ cc_test(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_googletest//:gtest_main",
         "@com_google_protobuf//:protobuf",
+        "@cross_media_measurement//src/test/cc/testutil:matchers",
+        "@cross_media_measurement//src/test/cc/testutil:status_macros",
         "@virtual_people_common//src/main/proto/wfa/virtual_people/common:model_cc_proto",
     ],
 )

--- a/src/main/cc/wfa/virtual_people/core/model/population_node_impl.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/population_node_impl.cc
@@ -20,8 +20,10 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
 #include "src/farmhash.h"
 #include "src/main/proto/wfa/virtual_people/common/model.pb.h"
+#include "wfa/measurement/common/macros.h"
 #include "wfa/virtual_people/core/model/model_node.h"
 #include "wfa/virtual_people/core/model/utils/virtual_person_selector.h"
 
@@ -32,21 +34,19 @@ absl::StatusOr<std::unique_ptr<PopulationNodeImpl>> PopulationNodeImpl::Build(
   if (!node_config.has_population_node()) {
     return absl::InvalidArgumentError("This is not a population node.");
   }
-  auto virtual_person_selector_or =
-      VirtualPersonSelector::Build(node_config.population_node().pools());
-  if (!virtual_person_selector_or.ok()) {
-    return virtual_person_selector_or.status();
-  }
+  ASSIGN_OR_RETURN(
+      std::unique_ptr<VirtualPersonSelector> virtual_person_selector,
+      VirtualPersonSelector::Build(node_config.population_node().pools()));
   return absl::make_unique<PopulationNodeImpl>(
       node_config,
-      std::move(virtual_person_selector_or.value()),
+      std::move(virtual_person_selector),
       node_config.population_node().random_seed());
 }
 
 PopulationNodeImpl::PopulationNodeImpl(
     const CompiledNode& node_config,
     std::unique_ptr<VirtualPersonSelector> virtual_person_selector,
-    const std::string& random_seed):
+    absl::string_view random_seed):
     ModelNode(node_config),
     virtual_person_selector_(std::move(virtual_person_selector)),
     random_seed_(random_seed) {}

--- a/src/main/cc/wfa/virtual_people/core/model/population_node_impl.h
+++ b/src/main/cc/wfa/virtual_people/core/model/population_node_impl.h
@@ -19,6 +19,7 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #include "src/main/proto/wfa/virtual_people/common/model.pb.h"
 #include "wfa/virtual_people/core/model/model_node.h"
 #include "wfa/virtual_people/core/model/utils/virtual_person_selector.h"
@@ -42,15 +43,15 @@ class PopulationNodeImpl : public ModelNode {
   explicit PopulationNodeImpl(
       const CompiledNode& node_config,
       std::unique_ptr<VirtualPersonSelector> virtual_person_selector,
-      const std::string& random_seed);
+      absl::string_view random_seed);
   ~PopulationNodeImpl() override {}
+
+  PopulationNodeImpl(const PopulationNodeImpl&) = delete;
+  PopulationNodeImpl& operator=(const PopulationNodeImpl&) = delete;
 
   // When Apply is called, exactly one id will be selected from the pools in
   // population_node, and assigned to virtual_person_activities[0] in @event.
   absl::Status Apply(LabelerEvent* event) const override;
-
-  PopulationNodeImpl(const PopulationNodeImpl&) = delete;
-  PopulationNodeImpl& operator=(const PopulationNodeImpl&) = delete;
 
  private:
   std::unique_ptr<VirtualPersonSelector> virtual_person_selector_;

--- a/src/main/cc/wfa/virtual_people/core/model/utils/BUILD.bazel
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/BUILD.bazel
@@ -27,6 +27,8 @@ cc_test(
         "@com_google_absl//absl/status:statusor",
         "@com_google_googletest//:gtest_main",
         "@com_google_protobuf//:protobuf",
+        "@cross_media_measurement//src/test/cc/testutil:matchers",
+        "@cross_media_measurement//src/test/cc/testutil:status_macros",
         "@virtual_people_common//src/main/proto/wfa/virtual_people/common:model_cc_proto",
     ],
 )

--- a/src/main/cc/wfa/virtual_people/core/model/utils/virtual_person_selector.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/virtual_person_selector.cc
@@ -63,16 +63,15 @@ absl::StatusOr<std::unique_ptr<VirtualPersonSelector>>
 VirtualPersonSelector::Build(
     const RepeatedPtrField<PopulationNode::VirtualPersonPool>& pools) {
   uint64_t total_population = 0;
-  std::unique_ptr<std::vector<VirtualPersonIdPool>> compiled_pools =
-      absl::make_unique<std::vector<VirtualPersonIdPool>>();
+  std::vector<VirtualPersonIdPool> compiled_pools;
   for (const PopulationNode::VirtualPersonPool& pool : pools) {
     if (pool.total_population() == 0) {
       // This pool is empty.
       continue;
     }
-    compiled_pools->emplace_back();
-    compiled_pools->back().virtual_people_id_offset = pool.population_offset();
-    compiled_pools->back().population_index_offset = total_population;
+    compiled_pools.emplace_back();
+    compiled_pools.back().virtual_people_id_offset = pool.population_offset();
+    compiled_pools.back().population_index_offset = total_population;
     total_population += pool.total_population();
   }
   if (total_population == 0) {
@@ -85,7 +84,7 @@ VirtualPersonSelector::Build(
 
 VirtualPersonSelector::VirtualPersonSelector(
     const uint64_t total_population,
-    std::unique_ptr<std::vector<VirtualPersonIdPool>> compiled_pools):
+    std::vector<VirtualPersonIdPool>&& compiled_pools):
     total_population_(total_population), pools_(std::move(compiled_pools)) {}
 
 int64_t VirtualPersonSelector::GetVirtualPersonId(
@@ -96,7 +95,7 @@ int64_t VirtualPersonSelector::GetVirtualPersonId(
   // Gets the first pool with population_index_offset larger than
   // population_index.
   auto it = std::upper_bound(
-      pools_->begin(), pools_->end(), population_index,
+      pools_.begin(), pools_.end(), population_index,
       [](uint64_t population_index, const VirtualPersonIdPool& pool) {
         return population_index < pool.population_index_offset;
       });

--- a/src/main/cc/wfa/virtual_people/core/model/utils/virtual_person_selector.h
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/virtual_person_selector.h
@@ -68,14 +68,14 @@ class VirtualPersonSelector {
   // Never call the constructor directly.
   explicit VirtualPersonSelector(
       uint64_t total_population,
-      std::unique_ptr<std::vector<VirtualPersonIdPool>> compiled_pools);
+      std::vector<VirtualPersonIdPool>&& compiled_pools);
+
+  VirtualPersonSelector(const VirtualPersonSelector&) = delete;
+  VirtualPersonSelector& operator=(const VirtualPersonSelector&) = delete;
 
   // Selects and returns an id from the virtual person pools, using consistent
   // hashing based on the random_seed.
   int64_t GetVirtualPersonId(uint64_t random_seed) const;
-
-  VirtualPersonSelector(const VirtualPersonSelector&) = delete;
-  VirtualPersonSelector& operator=(const VirtualPersonSelector&) = delete;
 
  private:
   // The sum of total population of all pools. Required for hashing.
@@ -83,7 +83,7 @@ class VirtualPersonSelector {
 
   // Stores the required information to compute the virtual person id after
   // hashing.
-  std::unique_ptr<std::vector<VirtualPersonIdPool>> pools_;
+  std::vector<VirtualPersonIdPool> pools_;
 };
 
 }  // namespace wfa_virtual_people

--- a/src/main/cc/wfa/virtual_people/core/model/utils/virtual_person_selector_test.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/utils/virtual_person_selector_test.cc
@@ -20,15 +20,22 @@
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
 #include "src/main/proto/wfa/virtual_people/common/model.pb.h"
+#include "src/test/cc/testutil/matchers.h"
+#include "src/test/cc/testutil/status_macros.h"
 
 namespace wfa_virtual_people {
 namespace {
+
+using ::testing::DoubleNear;
+using ::testing::Pair;
+using ::testing::UnorderedElementsAre;
+using ::wfa::StatusIs;
 
 constexpr int kSeedNumber = 10000;
 
 TEST(VirtualPersonSelectorTest, TestGetVirtualPersonId) {
   PopulationNode population_node;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"PROTO(
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
       pools {
         population_offset: 10
         total_population: 3
@@ -41,48 +48,40 @@ TEST(VirtualPersonSelectorTest, TestGetVirtualPersonId) {
         population_offset: 20
         total_population: 4
       }
-  )PROTO", &population_node));
-  absl::StatusOr<std::unique_ptr<VirtualPersonSelector>> selector_or =
-      VirtualPersonSelector::Build(population_node.pools());
-  EXPECT_TRUE(selector_or.ok());
-  std::unique_ptr<VirtualPersonSelector> selector =
-      std::move(selector_or.value());
+  )pb", &population_node));
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<VirtualPersonSelector> selector,
+      VirtualPersonSelector::Build(population_node.pools()));
 
-  // The pools will have 10 possible virtual person ids:
-  //   10, 11, 12, 30, 31, 32, 20, 21, 22, 23
-  absl::flat_hash_map<int64_t, int> id_counts = {
-      {10, 0},
-      {11, 0},
-      {12, 0},
-      {30, 0},
-      {31, 0},
-      {32, 0},
-      {20, 0},
-      {21, 0},
-      {22, 0},
-      {23, 0}
-    };
+  absl::flat_hash_map<int64_t, double> id_counts;
 
   for (int seed  = 0; seed < kSeedNumber; ++seed) {
     int64_t id = selector->GetVirtualPersonId(static_cast<uint64_t>(seed));
-    // The returned id should be one of the 10 possible values.
-    EXPECT_TRUE(id_counts.find(id) != id_counts.end());
     ++id_counts[id];
   }
-
-  for (auto const& x : id_counts) {
-    int count = x.second;
-    // The expected ratio for getting a given virtual person id is 1 / 10 = 10%.
-    // Absolute error more than 2% is very unlikely.
-    EXPECT_NEAR(static_cast<double>(count) / static_cast<double>(kSeedNumber),
-                0.1, 0.02);
+  for (auto& [key, value] : id_counts) {
+    value /= static_cast<double>(kSeedNumber);
   }
+
+  // The expected ratio for getting a given virtual person id is 1 / 10 = 10%.
+  // Absolute error more than 2% is very unlikely.
+  EXPECT_THAT(id_counts, UnorderedElementsAre(
+      Pair(10, DoubleNear(0.1, 0.02)),
+      Pair(11, DoubleNear(0.1, 0.02)),
+      Pair(12, DoubleNear(0.1, 0.02)),
+      Pair(30, DoubleNear(0.1, 0.02)),
+      Pair(31, DoubleNear(0.1, 0.02)),
+      Pair(32, DoubleNear(0.1, 0.02)),
+      Pair(20, DoubleNear(0.1, 0.02)),
+      Pair(21, DoubleNear(0.1, 0.02)),
+      Pair(22, DoubleNear(0.1, 0.02)),
+      Pair(23, DoubleNear(0.1, 0.02))));
 }
 
 TEST(VirtualPersonSelectorTest, TestInvalidPools) {
   // This is invalid as the total pools size is 0.
   PopulationNode population_node;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"PROTO(
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"pb(
       pools {
         population_offset: 10
         total_population: 0
@@ -95,10 +94,10 @@ TEST(VirtualPersonSelectorTest, TestInvalidPools) {
         population_offset: 20
         total_population: 0
       }
-  )PROTO", &population_node));
-  absl::StatusOr<std::unique_ptr<VirtualPersonSelector>> selector_or =
-      VirtualPersonSelector::Build(population_node.pools());
-  EXPECT_EQ(selector_or.status().code(), absl::StatusCode::kInvalidArgument);
+  )pb", &population_node));
+  EXPECT_THAT(
+      VirtualPersonSelector::Build(population_node.pools()).status(),
+      StatusIs(absl::StatusCode::kInvalidArgument, ""));
 }
 
 }  // namespace


### PR DESCRIPTION
Use "auto" when necessary.
Fix variable names.
Replace "std::string" with "absl::string_view".
Use macro to handle "absl::StatusOr" checking and assigning.
Use matchers in tests for better error message.
Remove unnecessary unique_ptr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/virtual-people-core-serving/5)
<!-- Reviewable:end -->
