### PR TITLE
Add pass-1 (pool-identity) labeling mode (Kotlin)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,7 +33,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "virtual-people-common",
-    version = "0.6.1",
+    version = "0.7.0",
     repo_name = "wfa_virtual_people_common",
 )
 

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/labeler/Labeler.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/labeler/Labeler.kt
@@ -26,18 +26,37 @@ import org.wfanet.virtualpeople.common.labelerOutput
 import org.wfanet.virtualpeople.core.common.Hashing
 import org.wfanet.virtualpeople.core.model.ModelNode
 
+enum class LabelingMode {
+  FULL,
+  POOL_IDENTITY,
+}
+
 class Labeler private constructor(private val rootNode: ModelNode) {
 
   /** Apply the model to generate the labels. Invalid inputs will result in an error. */
-  fun label(input: LabelerInput): LabelerOutput {
-    // Prepare labeler event.
+  fun label(input: LabelerInput): LabelerOutput = label(input, LabelingMode.FULL)
+
+  /**
+   * Apply the model with a specific labeling mode.
+   *
+   * In [LabelingMode.POOL_IDENTITY] mode, RankedPopulationNode leaves emit PoolAssignment entries
+   * instead of assigning VIDs.
+   */
+  fun label(input: LabelerInput, mode: LabelingMode): LabelerOutput {
     val eventBuilder = labelerEvent { labelerInput = input }.toBuilder()
     setFingerprints(eventBuilder)
+
+    if (mode == LabelingMode.POOL_IDENTITY) {
+      eventBuilder.poolIdentityMode = true
+    }
 
     rootNode.apply(eventBuilder)
 
     return labelerOutput {
       people.addAll(eventBuilder.virtualPersonActivitiesList)
+      if (eventBuilder.poolAssignmentsCount > 0) {
+        poolAssignments.addAll(eventBuilder.poolAssignmentsList)
+      }
       serializedDebugTrace = eventBuilder.toString()
     }
   }

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/labeler/Labeler.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/labeler/Labeler.kt
@@ -53,10 +53,8 @@ class Labeler private constructor(private val rootNode: ModelNode) {
     rootNode.apply(eventBuilder)
 
     return labelerOutput {
-      people.addAll(eventBuilder.virtualPersonActivitiesList)
-      if (eventBuilder.poolAssignmentsCount > 0) {
-        poolAssignments.addAll(eventBuilder.poolAssignmentsList)
-      }
+      people += eventBuilder.virtualPersonActivitiesList
+      poolAssignments += eventBuilder.poolAssignmentsList
       serializedDebugTrace = eventBuilder.toString()
     }
   }

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/model/BranchNodeImpl.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/model/BranchNodeImpl.kt
@@ -25,19 +25,19 @@ import org.wfanet.virtualpeople.core.model.utils.FieldFiltersMatcher
  * The implementation of the CompiledNode with branch_node set.
  *
  * @param nodeConfig the compiledNode used to build the branch node. The field branch_node must be
- * set.
+ *   set.
  * @param childNodes include the child nodes in all the branches, in the same order as the branches
- * in nodeConfig.
+ *   in nodeConfig.
  * @param hashing if chance is set in each branches in nodeConfig, hashing is set and used to select
- * a child node with randomSeed when Apply is called.
+ *   a child node with randomSeed when Apply is called.
  * @param randomSeed a seed used by the hashing.
  * @param matcher if condition is set in each branches in nodeConfig, matcher is set and used to
- * select the first child node whose condition matches when Apply is called.
+ *   select the first child node whose condition matches when Apply is called.
  * @param updaters if updates is set in nodeConfig, updaters is set. When calling Apply, entries of
- * [updaters] is applied to the event in order. Each entry of updaters updates the value of some
- * fields in the event.
+ *   [updaters] is applied to the event in order. Each entry of updaters updates the value of some
+ *   fields in the event.
  * @param multiplicity if multiplicity is set in nodeConfig, multiplicity is set. When calling
- * Apply, call ApplyMultiplicity.
+ *   Apply, call ApplyMultiplicity.
  */
 internal class BranchNodeImpl
 private constructor(
@@ -99,6 +99,14 @@ private constructor(
       clone.virtualPersonActivitiesList.forEach { person ->
         event.addVirtualPersonActivities(person)
       }
+      /**
+       * Fold back pool assignments too. In pool-identity (pass-1) mode, leaf nodes emit pool
+       * assignments instead of virtual person activities; without this, assignments from cloned
+       * multiplicity events would be dropped.
+       */
+      clone.poolAssignmentsList.forEach { poolAssignment ->
+        event.addPoolAssignments(poolAssignment)
+      }
     }
     return
   }
@@ -129,13 +137,13 @@ private constructor(
      * 1. [nodeConfig].branch_node is not set.
      * 2. [nodeConfig].branch_node.branches is empty.
      * 3. There is at least one of [nodeConfig].branch_node.branches, which has neither node_index
-     * nor node set.
+     *    nor node set.
      * 4. There is at least one of [nodeConfig].branch_node.branches, which has neither chance nor
-     * condition set.
+     *    condition set.
      * 5. At least one of [nodeConfig].branch_node.branches has chance set, and at least one of
-     * [nodeConfig].branch_node.branches has condition set.
+     *    [nodeConfig].branch_node.branches has condition set.
      * 6. When node_index is set in [nodeConfig].branch_node.branches. [nodeRefs] has no entry for
-     * this node_index.
+     *    this node_index.
      *
      * For any [nodeConfig].branch_node.branches with node_index set, the corresponding child node
      * is retrieved from [nodeRefs] using node_index as the key.

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/model/PopulationNodeImpl.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/model/PopulationNodeImpl.kt
@@ -36,11 +36,11 @@ private constructor(
    * assigned to virtual_person_activities[0] in [event].
    */
   override fun apply(event: LabelerEvent.Builder) {
+    // Pass-1 (pool-identity) mode: a plain PopulationNode has no ranked pool to
+    // announce, so it produces no output. This lets a model mix ranked and
+    // unranked leaves; events routing here are labeled normally in pass-2.
     if (event.poolIdentityMode) {
-      error(
-        "PopulationNodeImpl does not support pool-identity mode. " +
-          "Use RankedPopulationNode for two-pass labeling."
-      )
+      return
     }
 
     // Creates a new virtual_person_activities in the event and writes the

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/model/PopulationNodeImpl.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/model/PopulationNodeImpl.kt
@@ -40,6 +40,13 @@ private constructor(
      * Creates a new virtual_person_activities in [event] and write the virtual person id and label.
      * No virtual_person_activity should be added by previous nodes.
      */
+    if (event.poolIdentityMode) {
+      error(
+        "PopulationNodeImpl does not support pool-identity mode. " +
+          "Use RankedPopulationNode for two-pass labeling."
+      )
+    }
+
     if (event.virtualPersonActivitiesCount > 0) {
       error("virtual_person_activities should only be created in leaf nodes.")
     }

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
@@ -16,7 +16,7 @@ package org.wfanet.virtualpeople.core.model
 
 import org.wfanet.virtualpeople.common.CompiledNode
 import org.wfanet.virtualpeople.common.LabelerEvent
-import org.wfanet.virtualpeople.common.PoolAssignment
+import org.wfanet.virtualpeople.common.poolAssignment
 import org.wfanet.virtualpeople.common.RankedPopulationNode.UnrankedMode
 import org.wfanet.virtualpeople.common.VirtualPersonActivity
 import org.wfanet.virtualpeople.core.model.utils.Feistel
@@ -44,12 +44,11 @@ private constructor(
   override fun apply(event: LabelerEvent.Builder) {
     // Pass-1 mode: emit pool identity and return without assigning a VID.
     if (event.poolIdentityMode) {
-      event.addPoolAssignments(
-        PoolAssignment.newBuilder()
-          .setPoolOffset(poolOffset.toLong())
-          .setPoolSize(poolSize.toLong())
-          .setRankedSize(rankedSize.toLong())
-      )
+      event.addPoolAssignments(poolAssignment {
+        poolOffset = this@RankedPopulationNodeImpl.poolOffset.toLong()
+        poolSize = this@RankedPopulationNodeImpl.poolSize.toLong()
+        rankedSize = this@RankedPopulationNodeImpl.rankedSize.toLong()
+      })
       return
     }
 

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
@@ -44,11 +44,13 @@ private constructor(
   override fun apply(event: LabelerEvent.Builder) {
     // Pass-1 mode: emit pool identity and return without assigning a VID.
     if (event.poolIdentityMode) {
-      event.addPoolAssignments(poolAssignment {
-        poolOffset = this@RankedPopulationNodeImpl.poolOffset.toLong()
-        poolSize = this@RankedPopulationNodeImpl.poolSize.toLong()
-        rankedSize = this@RankedPopulationNodeImpl.rankedSize.toLong()
-      })
+      event.addPoolAssignments(
+        poolAssignment {
+          poolOffset = this@RankedPopulationNodeImpl.poolOffset.toLong()
+          poolSize = this@RankedPopulationNodeImpl.poolSize.toLong()
+          rankedSize = this@RankedPopulationNodeImpl.rankedSize.toLong()
+        }
+      )
       return
     }
 

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
@@ -16,9 +16,9 @@ package org.wfanet.virtualpeople.core.model
 
 import org.wfanet.virtualpeople.common.CompiledNode
 import org.wfanet.virtualpeople.common.LabelerEvent
-import org.wfanet.virtualpeople.common.poolAssignment
 import org.wfanet.virtualpeople.common.RankedPopulationNode.UnrankedMode
 import org.wfanet.virtualpeople.common.VirtualPersonActivity
+import org.wfanet.virtualpeople.common.poolAssignment
 import org.wfanet.virtualpeople.core.model.utils.Feistel
 import org.wfanet.virtualpeople.core.model.utils.PopulationNodeHelper
 import org.wfanet.virtualpeople.core.model.utils.jumpConsistentHash

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
@@ -16,8 +16,8 @@ package org.wfanet.virtualpeople.core.model
 
 import org.wfanet.virtualpeople.common.CompiledNode
 import org.wfanet.virtualpeople.common.LabelerEvent
-import org.wfanet.virtualpeople.common.RankedPopulationNode.UnrankedMode
 import org.wfanet.virtualpeople.common.PoolAssignment
+import org.wfanet.virtualpeople.common.RankedPopulationNode.UnrankedMode
 import org.wfanet.virtualpeople.common.VirtualPersonActivity
 import org.wfanet.virtualpeople.core.model.utils.Feistel
 import org.wfanet.virtualpeople.core.model.utils.PopulationNodeHelper

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
@@ -17,6 +17,7 @@ package org.wfanet.virtualpeople.core.model
 import org.wfanet.virtualpeople.common.CompiledNode
 import org.wfanet.virtualpeople.common.LabelerEvent
 import org.wfanet.virtualpeople.common.RankedPopulationNode.UnrankedMode
+import org.wfanet.virtualpeople.common.PoolAssignment
 import org.wfanet.virtualpeople.common.VirtualPersonActivity
 import org.wfanet.virtualpeople.core.model.utils.Feistel
 import org.wfanet.virtualpeople.core.model.utils.PopulationNodeHelper
@@ -41,6 +42,17 @@ private constructor(
 ) : ModelNode(nodeConfig) {
 
   override fun apply(event: LabelerEvent.Builder) {
+    // Pass-1 mode: emit pool identity and return without assigning a VID.
+    if (event.poolIdentityMode) {
+      event.addPoolAssignments(
+        PoolAssignment.newBuilder()
+          .setPoolOffset(poolOffset.toLong())
+          .setPoolSize(poolSize.toLong())
+          .setRankedSize(rankedSize.toLong())
+      )
+      return
+    }
+
     if (event.virtualPersonActivitiesCount > 0) {
       error("virtual_person_activities should only be created in leaf nodes.")
     }

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
@@ -59,12 +59,16 @@ private constructor(
 
     val activity = VirtualPersonActivity.newBuilder()
 
-    val rankAssignment =
-      if (event.hasLabelerInput()) {
-        event.labelerInput.rankAssignmentsList.firstOrNull { it.poolOffset.toULong() == poolOffset }
-      } else {
-        null
-      }
+    val rankAssignments =
+      if (event.hasLabelerInput()) event.labelerInput.rankAssignmentsList else emptyList()
+    val rankAssignment = rankAssignments.firstOrNull { it.poolOffset.toULong() == poolOffset }
+
+    if (rankAssignments.isNotEmpty() && rankAssignment == null) {
+      error(
+        "RankAssignment provided but none match pool_offset=$poolOffset. " +
+          "Available: ${rankAssignments.map { it.poolOffset }}."
+      )
+    }
 
     val virtualPersonId =
       if (rankAssignment != null && rankAssignment.localRank.toULong() < rankedSize) {

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -422,12 +422,13 @@ class RankedLabelingIntegrationTest {
     // Pass 2: inject ranks and assign VIDs.
     val vids = mutableSetOf<ULong>()
     inputs.forEachIndexed { rank, input ->
-      val rankedInput = input.copy {
-        rankAssignments += rankAssignment {
-          poolOffset = 0
-          localRank = rank.toLong()
+      val rankedInput =
+        input.copy {
+          rankAssignments += rankAssignment {
+            poolOffset = 0
+            localRank = rank.toLong()
+          }
         }
-      }
 
       val output = labeler.label(rankedInput)
       assertEquals(1, output.peopleCount)
@@ -462,10 +463,12 @@ class RankedLabelingIntegrationTest {
         val rankedInput =
           input
             .toBuilder()
-            .addRankAssignments(rankAssignment {
-              poolOffset = 0
-              localRank = rank.toLong()
-            })
+            .addRankAssignments(
+              rankAssignment {
+                poolOffset = 0
+                localRank = rank.toLong()
+              }
+            )
             .build()
         labeler.label(rankedInput).peopleList[0].virtualPersonId
       }

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -15,6 +15,7 @@
 package org.wfanet.virtualpeople.core.labeler
 
 import com.google.protobuf.TextFormat
+import kotlin.test.assertFailsWith
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.Test
@@ -342,7 +343,7 @@ class RankedLabelingIntegrationTest {
   }
 
   @Test
-  fun `pass 1 population node unaffected`() {
+  fun `pass 1 population node throws`() {
     val root = CompiledNode.newBuilder()
     TextFormat.merge(
       """
@@ -366,11 +367,10 @@ class RankedLabelingIntegrationTest {
         )
         .build()
 
-    val output = labeler.label(input, LabelingMode.POOL_IDENTITY)
-
-    // PopulationNode doesn't check pool_identity_mode — assigns VID normally.
-    assertEquals(1, output.peopleCount)
-    assertEquals(0, output.poolAssignmentsCount)
+    // PopulationNode does not support pool-identity mode — should throw.
+    assertFailsWith<IllegalStateException> {
+      labeler.label(input, LabelingMode.POOL_IDENTITY)
+    }
   }
 
   @Test
@@ -406,7 +406,7 @@ class RankedLabelingIntegrationTest {
     inputs.forEach { input ->
       val output = labeler.label(input, LabelingMode.POOL_IDENTITY)
       assertEquals(1, output.poolAssignmentsCount)
-      assertEquals(0, output.poolAssignmentsCount.let { output.peopleCount })
+      assertEquals(0, output.peopleCount)
     }
 
     // Pass 2: inject ranks and assign VIDs.
@@ -428,5 +428,42 @@ class RankedLabelingIntegrationTest {
 
     // All ranked events must produce unique VIDs.
     assertEquals(eventCount, vids.size, "Collision detected in two-pass flow")
+  }
+
+  @Test
+  fun `rank for non-existent pool falls back to unranked`() {
+    val root = CompiledNode.newBuilder()
+    TextFormat.merge(
+      """
+        name: "TestRankedNode"
+        ranked_population_node {
+          pools { population_offset: 100 total_population: 500 }
+          random_seed: "wrong-pool-seed"
+          ranked_size: 200
+          unranked_mode: DISJOINT
+        }
+      """,
+      root,
+    )
+
+    val labeler = Labeler.build(root.build())
+
+    // Rank assignment for pool_offset=9999 which doesn't match pool_offset=100.
+    val input =
+      LabelerInput.newBuilder()
+        .setEventId(
+          org.wfanet.virtualpeople.common.EventId.newBuilder()
+            .setPublisher("test")
+            .setId("wrong-pool-event")
+        )
+        .addRankAssignments(RankAssignment.newBuilder().setPoolOffset(9999).setLocalRank(5))
+        .build()
+
+    val output = labeler.label(input)
+    assertEquals(1, output.peopleCount)
+    val vid = output.peopleList[0].virtualPersonId.toULong()
+    // No matching rank — falls back to DISJOINT unranked range.
+    assertTrue(vid >= 300uL, "VID $vid should be in unranked range")
+    assertTrue(vid < 600uL, "VID $vid should be in unranked range")
   }
 }

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -212,14 +212,23 @@ class RankedLabelingIntegrationTest {
     """
       )
 
+    // Event carries rank assignments for multiple pools — only pool_offset=500 should match.
     val input = labelerInput {
       eventId = eventId {
         publisher = "test"
         id = "multi-rank-event"
       }
       rankAssignments += rankAssignment {
+        poolOffset = 100
+        localRank = 5
+      }
+      rankAssignments += rankAssignment {
         poolOffset = 500
         localRank = 10
+      }
+      rankAssignments += rankAssignment {
+        poolOffset = 9000
+        localRank = 99
       }
     }
 
@@ -412,14 +421,12 @@ class RankedLabelingIntegrationTest {
     // Pass 2: inject ranks and assign VIDs.
     val vids = mutableSetOf<ULong>()
     inputs.forEachIndexed { rank, input ->
-      val rankedInput =
-        input
-          .toBuilder()
-          .addRankAssignments(rankAssignment {
-            poolOffset = 0
-            localRank = rank.toLong()
-          })
-          .build()
+      val rankedInput = input.copy {
+        rankAssignments += rankAssignment {
+          poolOffset = 0
+          localRank = rank.toLong()
+        }
+      }
 
       val output = labeler.label(rankedInput)
       assertEquals(1, output.peopleCount)

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -421,12 +421,11 @@ class RankedLabelingIntegrationTest {
     // Pass 2: inject ranks and assign VIDs.
     val vids = mutableSetOf<ULong>()
     inputs.forEachIndexed { rank, input ->
-      val rankedInput = input.copy {
-        rankAssignments += rankAssignment {
+      val rankedInput =
+        input.toBuilder().addRankAssignments(rankAssignment {
           poolOffset = 0
           localRank = rank.toLong()
-        }
-      }
+        }).build()
 
       val output = labeler.label(rankedInput)
       assertEquals(1, output.peopleCount)

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -412,13 +412,14 @@ class RankedLabelingIntegrationTest {
     // Pass 2: inject ranks and assign VIDs.
     val vids = mutableSetOf<ULong>()
     inputs.forEachIndexed { rank, input ->
-      val rankedInput = labelerInput {
-        mergeFrom(input)
-        rankAssignments += rankAssignment {
-          poolOffset = 0
-          localRank = rank.toLong()
-        }
-      }
+      val rankedInput =
+        input
+          .toBuilder()
+          .addRankAssignments(rankAssignment {
+            poolOffset = 0
+            localRank = rank.toLong()
+          })
+          .build()
 
       val output = labeler.label(rankedInput)
       assertEquals(1, output.peopleCount)
@@ -450,13 +451,14 @@ class RankedLabelingIntegrationTest {
     // Run two-pass twice and verify identical VIDs.
     fun runTwoPass(): List<Long> {
       return inputs.mapIndexed { rank, input ->
-        val rankedInput = labelerInput {
-          mergeFrom(input)
-          rankAssignments += rankAssignment {
-            poolOffset = 0
-            localRank = rank.toLong()
-          }
-        }
+        val rankedInput =
+          input
+            .toBuilder()
+            .addRankAssignments(rankAssignment {
+              poolOffset = 0
+              localRank = rank.toLong()
+            })
+            .build()
         labeler.label(rankedInput).peopleList[0].virtualPersonId
       }
     }

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -412,7 +412,8 @@ class RankedLabelingIntegrationTest {
     val vids = mutableSetOf<ULong>()
     inputs.forEachIndexed { rank, input ->
       val rankedInput =
-        input.toBuilder()
+        input
+          .toBuilder()
           .addRankAssignments(
             RankAssignment.newBuilder().setPoolOffset(0).setLocalRank(rank.toLong())
           )

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -22,89 +22,84 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.virtualpeople.common.CompiledNode
-import org.wfanet.virtualpeople.common.LabelerInput
-import org.wfanet.virtualpeople.common.RankAssignment
+import org.wfanet.virtualpeople.common.eventId
+import org.wfanet.virtualpeople.common.labelerInput
+import org.wfanet.virtualpeople.common.rankAssignment
 
 @RunWith(JUnit4::class)
 class RankedLabelingIntegrationTest {
 
+  private fun buildLabeler(protoText: String): Labeler {
+    val root = CompiledNode.newBuilder()
+    TextFormat.merge(protoText, root)
+    return Labeler.build(root.build())
+  }
+
+  private fun makeInput(id: String) = labelerInput {
+    eventId = eventId {
+      publisher = "test"
+      this.id = id
+    }
+  }
+
   @Test
   fun `ranked events produce collision free VIDs`() {
-    val root = CompiledNode.newBuilder()
-    TextFormat.merge(
-      """
-        name: "TestRankedNode"
-        ranked_population_node {
-          pools { population_offset: 100 total_population: 500 }
-          random_seed: "test-seed"
-          ranked_size: 200
-          unranked_mode: DISJOINT
-        }
-      """,
-      root,
-    )
+    val labeler =
+      buildLabeler(
+        """
+      name: "TestRankedNode"
+      ranked_population_node {
+        pools { population_offset: 100 total_population: 500 }
+        random_seed: "test-seed"
+        ranked_size: 200
+        unranked_mode: DISJOINT
+      }
+    """
+      )
 
-    val labeler = Labeler.build(root.build())
     val vids = mutableSetOf<ULong>()
-
     for (rank in 0uL until 200uL) {
-      val input =
-        LabelerInput.newBuilder()
-          .setEventId(
-            org.wfanet.virtualpeople.common.EventId.newBuilder()
-              .setPublisher("test")
-              .setId(rank.toString())
-          )
-          .addRankAssignments(
-            RankAssignment.newBuilder().setPoolOffset(100).setLocalRank(rank.toLong())
-          )
-          .build()
+      val input = labelerInput {
+        eventId = eventId {
+          publisher = "test"
+          id = rank.toString()
+        }
+        rankAssignments += rankAssignment {
+          poolOffset = 100
+          localRank = rank.toLong()
+        }
+      }
 
       val output = labeler.label(input)
       assertEquals(1, output.peopleCount)
       val vid = output.peopleList[0].virtualPersonId.toULong()
-      // Ranked VIDs in [pool_offset, pool_offset + ranked_size)
       assertTrue(vid >= 100uL, "VID $vid below pool_offset")
       assertTrue(vid < 300uL, "VID $vid above ranked range")
       vids.add(vid)
     }
 
-    // All 200 ranked events must produce 200 distinct VIDs.
     assertEquals(200, vids.size, "Collision detected in ranked VIDs")
   }
 
   @Test
   fun `unranked disjoint events get VIDs in unranked range`() {
-    val root = CompiledNode.newBuilder()
-    TextFormat.merge(
-      """
-        name: "TestRankedNode"
-        ranked_population_node {
-          pools { population_offset: 100 total_population: 500 }
-          random_seed: "test-seed"
-          ranked_size: 200
-          unranked_mode: DISJOINT
-        }
-      """,
-      root,
-    )
-
-    val labeler = Labeler.build(root.build())
+    val labeler =
+      buildLabeler(
+        """
+      name: "TestRankedNode"
+      ranked_population_node {
+        pools { population_offset: 100 total_population: 500 }
+        random_seed: "test-seed"
+        ranked_size: 200
+        unranked_mode: DISJOINT
+      }
+    """
+      )
 
     for (i in 0 until 50) {
-      val input =
-        LabelerInput.newBuilder()
-          .setEventId(
-            org.wfanet.virtualpeople.common.EventId.newBuilder()
-              .setPublisher("test")
-              .setId("unranked-$i")
-          )
-          .build()
-
-      val output = labeler.label(input)
+      val output = labeler.label(makeInput("unranked-$i"))
       assertEquals(1, output.peopleCount)
       val vid = output.peopleList[0].virtualPersonId.toULong()
-      // DISJOINT: VIDs in [pool_offset + ranked_size, pool_offset + pool_size)
       assertTrue(vid >= 300uL, "VID $vid below unranked range")
       assertTrue(vid < 600uL, "VID $vid above pool range")
     }
@@ -112,36 +107,23 @@ class RankedLabelingIntegrationTest {
 
   @Test
   fun `unranked full pool events get VIDs in full range`() {
-    val root = CompiledNode.newBuilder()
-    TextFormat.merge(
-      """
-        name: "TestRankedNode"
-        ranked_population_node {
-          pools { population_offset: 100 total_population: 500 }
-          random_seed: "test-seed"
-          ranked_size: 200
-          unranked_mode: FULL_POOL
-        }
-      """,
-      root,
-    )
-
-    val labeler = Labeler.build(root.build())
+    val labeler =
+      buildLabeler(
+        """
+      name: "TestRankedNode"
+      ranked_population_node {
+        pools { population_offset: 100 total_population: 500 }
+        random_seed: "test-seed"
+        ranked_size: 200
+        unranked_mode: FULL_POOL
+      }
+    """
+      )
 
     for (i in 0 until 50) {
-      val input =
-        LabelerInput.newBuilder()
-          .setEventId(
-            org.wfanet.virtualpeople.common.EventId.newBuilder()
-              .setPublisher("test")
-              .setId("fullpool-$i")
-          )
-          .build()
-
-      val output = labeler.label(input)
+      val output = labeler.label(makeInput("fullpool-$i"))
       assertEquals(1, output.peopleCount)
       val vid = output.peopleList[0].virtualPersonId.toULong()
-      // FULL_POOL: VIDs in [pool_offset, pool_offset + pool_size)
       assertTrue(vid >= 100uL, "VID $vid below pool range")
       assertTrue(vid < 600uL, "VID $vid above pool range")
     }
@@ -149,157 +131,162 @@ class RankedLabelingIntegrationTest {
 
   @Test
   fun `rank overflow falls back to unranked path`() {
-    val root = CompiledNode.newBuilder()
-    TextFormat.merge(
-      """
-        name: "TestRankedNode"
-        ranked_population_node {
-          pools { population_offset: 100 total_population: 500 }
-          random_seed: "overflow-seed"
-          ranked_size: 200
-          unranked_mode: DISJOINT
-        }
-      """,
-      root,
-    )
+    val labeler =
+      buildLabeler(
+        """
+      name: "TestRankedNode"
+      ranked_population_node {
+        pools { population_offset: 100 total_population: 500 }
+        random_seed: "overflow-seed"
+        ranked_size: 200
+        unranked_mode: DISJOINT
+      }
+    """
+      )
 
-    val labeler = Labeler.build(root.build())
-
-    // local_rank=250 >= ranked_size=200 — should fall back to unranked DISJOINT range.
-    val input =
-      LabelerInput.newBuilder()
-        .setEventId(
-          org.wfanet.virtualpeople.common.EventId.newBuilder()
-            .setPublisher("test")
-            .setId("overflow-event")
-        )
-        .addRankAssignments(RankAssignment.newBuilder().setPoolOffset(100).setLocalRank(250))
-        .build()
+    // local_rank=250 > ranked_size=200 — should fall back to unranked.
+    val input = labelerInput {
+      eventId = eventId {
+        publisher = "test"
+        id = "overflow-event"
+      }
+      rankAssignments += rankAssignment {
+        poolOffset = 100
+        localRank = 250
+      }
+    }
 
     val output = labeler.label(input)
     assertEquals(1, output.peopleCount)
     val vid = output.peopleList[0].virtualPersonId.toULong()
-    // DISJOINT unranked range: [pool_offset + ranked_size, pool_offset + pool_size)
     assertTrue(vid >= 300uL, "Overflow VID $vid should be in unranked range")
     assertTrue(vid < 600uL, "Overflow VID $vid should be in unranked range")
   }
 
   @Test
   fun `boundary rank equals ranked size falls back to unranked`() {
-    val root = CompiledNode.newBuilder()
-    TextFormat.merge(
-      """
-        name: "TestRankedNode"
-        ranked_population_node {
-          pools { population_offset: 100 total_population: 500 }
-          random_seed: "boundary-seed"
-          ranked_size: 200
-          unranked_mode: DISJOINT
-        }
-      """,
-      root,
-    )
-
-    val labeler = Labeler.build(root.build())
+    val labeler =
+      buildLabeler(
+        """
+      name: "TestRankedNode"
+      ranked_population_node {
+        pools { population_offset: 100 total_population: 500 }
+        random_seed: "boundary-seed"
+        ranked_size: 200
+        unranked_mode: DISJOINT
+      }
+    """
+      )
 
     // local_rank=200 == ranked_size=200 — exactly at boundary, should fall back to unranked.
-    val input =
-      LabelerInput.newBuilder()
-        .setEventId(
-          org.wfanet.virtualpeople.common.EventId.newBuilder()
-            .setPublisher("test")
-            .setId("boundary-event")
-        )
-        .addRankAssignments(RankAssignment.newBuilder().setPoolOffset(100).setLocalRank(200))
-        .build()
+    val input = labelerInput {
+      eventId = eventId {
+        publisher = "test"
+        id = "boundary-event"
+      }
+      rankAssignments += rankAssignment {
+        poolOffset = 100
+        localRank = 200
+      }
+    }
 
     val output = labeler.label(input)
     assertEquals(1, output.peopleCount)
     val vid = output.peopleList[0].virtualPersonId.toULong()
-    // DISJOINT unranked range: [pool_offset + ranked_size, pool_offset + pool_size)
     assertTrue(vid >= 300uL, "Boundary VID $vid should be in unranked range")
     assertTrue(vid < 600uL, "Boundary VID $vid should be in unranked range")
   }
 
   @Test
   fun `multiple rank assignments resolves correct pool`() {
-    val root = CompiledNode.newBuilder()
-    TextFormat.merge(
-      """
-        name: "TestRankedNode"
-        ranked_population_node {
-          pools { population_offset: 500 total_population: 1000 }
-          random_seed: "multi-rank-seed"
-          ranked_size: 400
-          unranked_mode: DISJOINT
-        }
-      """,
-      root,
-    )
+    val labeler =
+      buildLabeler(
+        """
+      name: "TestRankedNode"
+      ranked_population_node {
+        pools { population_offset: 500 total_population: 1000 }
+        random_seed: "multi-rank-seed"
+        ranked_size: 400
+        unranked_mode: DISJOINT
+      }
+    """
+      )
 
-    val labeler = Labeler.build(root.build())
-
-    // Event carries rank assignments for multiple pools — only pool_offset=500 should match.
-    val input =
-      LabelerInput.newBuilder()
-        .setEventId(
-          org.wfanet.virtualpeople.common.EventId.newBuilder()
-            .setPublisher("test")
-            .setId("multi-rank-event")
-        )
-        .addRankAssignments(RankAssignment.newBuilder().setPoolOffset(100).setLocalRank(5))
-        .addRankAssignments(RankAssignment.newBuilder().setPoolOffset(500).setLocalRank(10))
-        .addRankAssignments(RankAssignment.newBuilder().setPoolOffset(9000).setLocalRank(99))
-        .build()
+    val input = labelerInput {
+      eventId = eventId {
+        publisher = "test"
+        id = "multi-rank-event"
+      }
+      rankAssignments += rankAssignment {
+        poolOffset = 500
+        localRank = 10
+      }
+    }
 
     val output = labeler.label(input)
     assertEquals(1, output.peopleCount)
     val vid = output.peopleList[0].virtualPersonId.toULong()
-    // Should use pool_offset=500, local_rank=10 → ranked path: [500, 900)
     assertTrue(vid >= 500uL, "VID $vid should be in ranked range for pool 500")
     assertTrue(vid < 900uL, "VID $vid should be in ranked range for pool 500")
   }
 
   @Test
+  fun `rank for non-existent pool throws`() {
+    val labeler =
+      buildLabeler(
+        """
+      name: "TestRankedNode"
+      ranked_population_node {
+        pools { population_offset: 100 total_population: 500 }
+        random_seed: "wrong-pool-seed"
+        ranked_size: 200
+        unranked_mode: DISJOINT
+      }
+    """
+      )
+
+    val input = labelerInput {
+      eventId = eventId {
+        publisher = "test"
+        id = "wrong-pool-event"
+      }
+      rankAssignments += rankAssignment {
+        poolOffset = 9999
+        localRank = 5
+      }
+    }
+
+    assertFailsWith<IllegalStateException> { labeler.label(input) }
+  }
+
+  @Test
   fun `ranked size zero produces same VIDs as PopulationNode`() {
-    val rankedRoot = CompiledNode.newBuilder()
-    TextFormat.merge(
-      """
-        name: "RankedNode"
-        ranked_population_node {
-          pools { population_offset: 100 total_population: 500 }
-          random_seed: "same-seed"
-          ranked_size: 0
-          unranked_mode: FULL_POOL
-        }
-      """,
-      rankedRoot,
-    )
+    val rankedLabeler =
+      buildLabeler(
+        """
+      name: "RankedNode"
+      ranked_population_node {
+        pools { population_offset: 100 total_population: 500 }
+        random_seed: "same-seed"
+        ranked_size: 0
+        unranked_mode: FULL_POOL
+      }
+    """
+      )
 
-    val populationRoot = CompiledNode.newBuilder()
-    TextFormat.merge(
-      """
-        name: "PopNode"
-        population_node {
-          pools { population_offset: 100 total_population: 500 }
-          random_seed: "same-seed"
-        }
-      """,
-      populationRoot,
-    )
-
-    val rankedLabeler = Labeler.build(rankedRoot.build())
-    val popLabeler = Labeler.build(populationRoot.build())
+    val popLabeler =
+      buildLabeler(
+        """
+      name: "PopNode"
+      population_node {
+        pools { population_offset: 100 total_population: 500 }
+        random_seed: "same-seed"
+      }
+    """
+      )
 
     for (i in 0 until 100) {
-      val input =
-        LabelerInput.newBuilder()
-          .setEventId(
-            org.wfanet.virtualpeople.common.EventId.newBuilder()
-              .setPublisher("test")
-              .setId("event-$i")
-          )
-          .build()
+      val input = makeInput("event-$i")
       val rankedVid = rankedLabeler.label(input).peopleList[0].virtualPersonId
       val popVid = popLabeler.label(input).peopleList[0].virtualPersonId
       assertEquals(popVid, rankedVid, "VID mismatch for event-$i")
@@ -308,32 +295,20 @@ class RankedLabelingIntegrationTest {
 
   @Test
   fun `pass 1 emits pool assignment without VID`() {
-    val root = CompiledNode.newBuilder()
-    TextFormat.merge(
-      """
-        name: "TestRankedNode"
-        ranked_population_node {
-          pools { population_offset: 100 total_population: 500 }
-          random_seed: "pass1-seed"
-          ranked_size: 200
-          unranked_mode: DISJOINT
-        }
-      """,
-      root,
-    )
+    val labeler =
+      buildLabeler(
+        """
+      name: "TestRankedNode"
+      ranked_population_node {
+        pools { population_offset: 100 total_population: 500 }
+        random_seed: "pass1-seed"
+        ranked_size: 200
+        unranked_mode: DISJOINT
+      }
+    """
+      )
 
-    val labeler = Labeler.build(root.build())
-
-    val input =
-      LabelerInput.newBuilder()
-        .setEventId(
-          org.wfanet.virtualpeople.common.EventId.newBuilder()
-            .setPublisher("test")
-            .setId("pass1-event")
-        )
-        .build()
-
-    val output = labeler.label(input, LabelingMode.POOL_IDENTITY)
+    val output = labeler.label(makeInput("pass1-event"), LabelingMode.POOL_IDENTITY)
 
     assertEquals(0, output.peopleCount, "Pass-1 should not assign VIDs")
     assertEquals(1, output.poolAssignmentsCount, "Pass-1 should emit pool assignment")
@@ -344,63 +319,89 @@ class RankedLabelingIntegrationTest {
 
   @Test
   fun `pass 1 population node throws`() {
-    val root = CompiledNode.newBuilder()
-    TextFormat.merge(
-      """
-        name: "PopNode"
-        population_node {
-          pools { population_offset: 10 total_population: 100 }
-          random_seed: "pop-seed"
+    val labeler =
+      buildLabeler(
+        """
+      name: "PopNode"
+      population_node {
+        pools { population_offset: 10 total_population: 100 }
+        random_seed: "pop-seed"
+      }
+    """
+      )
+
+    assertFailsWith<IllegalStateException> {
+      labeler.label(makeInput("pop-event"), LabelingMode.POOL_IDENTITY)
+    }
+  }
+
+  @Test
+  fun `pass 1 branch node routes to correct pools`() {
+    val labeler =
+      buildLabeler(
+        """
+      name: "Root"
+      branch_node {
+        branches {
+          node {
+            name: "PoolA"
+            ranked_population_node {
+              pools { population_offset: 1000 total_population: 500 }
+              random_seed: "pool-a-seed"
+              ranked_size: 200
+              unranked_mode: DISJOINT
+            }
+          }
+          chance: 0.5
         }
-      """,
-      root,
-    )
+        branches {
+          node {
+            name: "PoolB"
+            ranked_population_node {
+              pools { population_offset: 5000 total_population: 500 }
+              random_seed: "pool-b-seed"
+              ranked_size: 300
+              unranked_mode: FULL_POOL
+            }
+          }
+          chance: 0.5
+        }
+        random_seed: "branch-seed"
+      }
+    """
+      )
 
-    val labeler = Labeler.build(root.build())
+    val poolOffsets = mutableSetOf<Long>()
+    for (i in 0 until 200) {
+      val output = labeler.label(makeInput("branch-$i"), LabelingMode.POOL_IDENTITY)
+      assertEquals(1, output.poolAssignmentsCount)
+      assertEquals(0, output.peopleCount)
+      poolOffsets.add(output.poolAssignmentsList[0].poolOffset)
+    }
 
-    val input =
-      LabelerInput.newBuilder()
-        .setEventId(
-          org.wfanet.virtualpeople.common.EventId.newBuilder()
-            .setPublisher("test")
-            .setId("pop-event")
-        )
-        .build()
-
-    // PopulationNode does not support pool-identity mode — should throw.
-    assertFailsWith<IllegalStateException> { labeler.label(input, LabelingMode.POOL_IDENTITY) }
+    assertTrue(poolOffsets.contains(1000L), "No events routed to pool A")
+    assertTrue(poolOffsets.contains(5000L), "No events routed to pool B")
   }
 
   @Test
   fun `two pass collision free end to end`() {
-    val root = CompiledNode.newBuilder()
-    TextFormat.merge(
-      """
-        name: "TestRankedNode"
-        ranked_population_node {
-          pools { population_offset: 0 total_population: 300 }
-          random_seed: "two-pass-seed"
-          ranked_size: 100
-          unranked_mode: DISJOINT
-        }
-      """,
-      root,
-    )
+    val labeler =
+      buildLabeler(
+        """
+      name: "TestRankedNode"
+      ranked_population_node {
+        pools { population_offset: 0 total_population: 300 }
+        random_seed: "two-pass-seed"
+        ranked_size: 100
+        unranked_mode: DISJOINT
+      }
+    """
+      )
 
-    val labeler = Labeler.build(root.build())
     val eventCount = 100
 
     // Pass 1: collect pool assignments.
-    val inputs =
-      (0 until eventCount).map { i ->
-        LabelerInput.newBuilder()
-          .setEventId(
-            org.wfanet.virtualpeople.common.EventId.newBuilder()
-              .setPublisher("test")
-              .setId("event-$i")
-          )
-          .build()
-      }
+    val inputs = (0 until eventCount).map { makeInput("event-$it") }
 
     inputs.forEach { input ->
       val output = labeler.label(input, LabelingMode.POOL_IDENTITY)
@@ -411,13 +412,13 @@ class RankedLabelingIntegrationTest {
     // Pass 2: inject ranks and assign VIDs.
     val vids = mutableSetOf<ULong>()
     inputs.forEachIndexed { rank, input ->
-      val rankedInput =
-        input
-          .toBuilder()
-          .addRankAssignments(
-            RankAssignment.newBuilder().setPoolOffset(0).setLocalRank(rank.toLong())
-          )
-          .build()
+      val rankedInput = labelerInput {
+        mergeFrom(input)
+        rankAssignments += rankAssignment {
+          poolOffset = 0
+          localRank = rank.toLong()
+        }
+      }
 
       val output = labeler.label(rankedInput)
       assertEquals(1, output.peopleCount)
@@ -426,44 +427,42 @@ class RankedLabelingIntegrationTest {
       vids.add(vid)
     }
 
-    // All ranked events must produce unique VIDs.
     assertEquals(eventCount, vids.size, "Collision detected in two-pass flow")
   }
 
   @Test
-  fun `rank for non-existent pool falls back to unranked`() {
-    val root = CompiledNode.newBuilder()
-    TextFormat.merge(
-      """
-        name: "TestRankedNode"
-        ranked_population_node {
-          pools { population_offset: 100 total_population: 500 }
-          random_seed: "wrong-pool-seed"
-          ranked_size: 200
-          unranked_mode: DISJOINT
+  fun `two pass is deterministic`() {
+    val labeler =
+      buildLabeler(
+        """
+      name: "TestRankedNode"
+      ranked_population_node {
+        pools { population_offset: 0 total_population: 200 }
+        random_seed: "determinism-seed"
+        ranked_size: 50
+        unranked_mode: DISJOINT
+      }
+    """
+      )
+
+    val inputs = (0 until 50).map { makeInput("det-$it") }
+
+    // Run two-pass twice and verify identical VIDs.
+    fun runTwoPass(): List<Long> {
+      return inputs.mapIndexed { rank, input ->
+        val rankedInput = labelerInput {
+          mergeFrom(input)
+          rankAssignments += rankAssignment {
+            poolOffset = 0
+            localRank = rank.toLong()
+          }
         }
-      """,
-      root,
-    )
+        labeler.label(rankedInput).peopleList[0].virtualPersonId
+      }
+    }
 
-    val labeler = Labeler.build(root.build())
-
-    // Rank assignment for pool_offset=9999 which doesn't match pool_offset=100.
-    val input =
-      LabelerInput.newBuilder()
-        .setEventId(
-          org.wfanet.virtualpeople.common.EventId.newBuilder()
-            .setPublisher("test")
-            .setId("wrong-pool-event")
-        )
-        .addRankAssignments(RankAssignment.newBuilder().setPoolOffset(9999).setLocalRank(5))
-        .build()
-
-    val output = labeler.label(input)
-    assertEquals(1, output.peopleCount)
-    val vid = output.peopleList[0].virtualPersonId.toULong()
-    // No matching rank — falls back to DISJOINT unranked range.
-    assertTrue(vid >= 300uL, "VID $vid should be in unranked range")
-    assertTrue(vid < 600uL, "VID $vid should be in unranked range")
+    val run1 = runTwoPass()
+    val run2 = runTwoPass()
+    assertEquals(run1, run2, "Two-pass should be deterministic")
   }
 }

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -461,15 +461,12 @@ class RankedLabelingIntegrationTest {
     fun runTwoPass(): List<Long> {
       return inputs.mapIndexed { rank, input ->
         val rankedInput =
-          input
-            .toBuilder()
-            .addRankAssignments(
-              rankAssignment {
-                poolOffset = 0
-                localRank = rank.toLong()
-              }
-            )
-            .build()
+          input.copy {
+            rankAssignments += rankAssignment {
+              poolOffset = 0
+              localRank = rank.toLong()
+            }
+          }
         labeler.label(rankedInput).peopleList[0].virtualPersonId
       }
     }

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -328,7 +328,7 @@ class RankedLabelingIntegrationTest {
   }
 
   @Test
-  fun `pass 1 population node throws`() {
+  fun `pass 1 population node produces no output`() {
     val labeler =
       buildLabeler(
         """
@@ -340,9 +340,72 @@ class RankedLabelingIntegrationTest {
     """
       )
 
-    assertFailsWith<IllegalStateException> {
-      labeler.label(makeInput("pop-event"), LabelingMode.POOL_IDENTITY)
+    val output = labeler.label(makeInput("pop-event"), LabelingMode.POOL_IDENTITY)
+
+    assertEquals(0, output.peopleCount, "Pass-1 PopulationNode should not assign VIDs")
+    assertEquals(
+      0,
+      output.poolAssignmentsCount,
+      "Pass-1 PopulationNode should emit no pool assignment"
+    )
+  }
+
+  @Test
+  fun `pass 1 mixed model emits assignments only for ranked leaf`() {
+    // A model may mix a RankedPopulationNode leaf (needs ranking) and a plain
+    // PopulationNode leaf (does not). In pass-1, events routing to the ranked
+    // leaf emit a PoolAssignment; events routing to the vanilla leaf emit
+    // nothing. No VIDs are assigned in either case.
+    val labeler =
+      buildLabeler(
+        """
+      name: "Root"
+      branch_node {
+        branches {
+          node {
+            name: "RankedLeaf"
+            ranked_population_node {
+              pools { population_offset: 1000 total_population: 500 }
+              random_seed: "ranked-seed"
+              ranked_size: 200
+              unranked_mode: DISJOINT
+            }
+          }
+          chance: 0.5
+        }
+        branches {
+          node {
+            name: "VanillaLeaf"
+            population_node {
+              pools { population_offset: 10 total_population: 100 }
+              random_seed: "vanilla-seed"
+            }
+          }
+          chance: 0.5
+        }
+        random_seed: "branch-seed"
+      }
+    """
+      )
+
+    var rankedCount = 0
+    var vanillaCount = 0
+    for (i in 0 until 200) {
+      val output = labeler.label(makeInput("mixed-$i"), LabelingMode.POOL_IDENTITY)
+      assertEquals(0, output.peopleCount, "Pass-1 should never assign VIDs")
+      when (output.poolAssignmentsCount) {
+        1 -> {
+          assertEquals(1000L, output.poolAssignmentsList[0].poolOffset)
+          rankedCount++
+        }
+        0 -> vanillaCount++
+        else -> error("Unexpected pool assignment count ${output.poolAssignmentsCount}")
+      }
     }
+
+    assertTrue(rankedCount > 0, "No events routed to the ranked leaf")
+    assertTrue(vanillaCount > 0, "No events routed to the vanilla PopulationNode leaf")
+    assertEquals(200, rankedCount + vanillaCount)
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -304,4 +304,129 @@ class RankedLabelingIntegrationTest {
       assertEquals(popVid, rankedVid, "VID mismatch for event-$i")
     }
   }
+
+  @Test
+  fun `pass 1 emits pool assignment without VID`() {
+    val root = CompiledNode.newBuilder()
+    TextFormat.merge(
+      """
+        name: "TestRankedNode"
+        ranked_population_node {
+          pools { population_offset: 100 total_population: 500 }
+          random_seed: "pass1-seed"
+          ranked_size: 200
+          unranked_mode: DISJOINT
+        }
+      """,
+      root,
+    )
+
+    val labeler = Labeler.build(root.build())
+
+    val input =
+      LabelerInput.newBuilder()
+        .setEventId(
+          org.wfanet.virtualpeople.common.EventId.newBuilder()
+            .setPublisher("test")
+            .setId("pass1-event")
+        )
+        .build()
+
+    val output = labeler.label(input, LabelingMode.POOL_IDENTITY)
+
+    assertEquals(0, output.peopleCount, "Pass-1 should not assign VIDs")
+    assertEquals(1, output.poolAssignmentsCount, "Pass-1 should emit pool assignment")
+    assertEquals(100L, output.poolAssignmentsList[0].poolOffset)
+    assertEquals(500L, output.poolAssignmentsList[0].poolSize)
+    assertEquals(200L, output.poolAssignmentsList[0].rankedSize)
+  }
+
+  @Test
+  fun `pass 1 population node unaffected`() {
+    val root = CompiledNode.newBuilder()
+    TextFormat.merge(
+      """
+        name: "PopNode"
+        population_node {
+          pools { population_offset: 10 total_population: 100 }
+          random_seed: "pop-seed"
+        }
+      """,
+      root,
+    )
+
+    val labeler = Labeler.build(root.build())
+
+    val input =
+      LabelerInput.newBuilder()
+        .setEventId(
+          org.wfanet.virtualpeople.common.EventId.newBuilder()
+            .setPublisher("test")
+            .setId("pop-event")
+        )
+        .build()
+
+    val output = labeler.label(input, LabelingMode.POOL_IDENTITY)
+
+    // PopulationNode doesn't check pool_identity_mode — assigns VID normally.
+    assertEquals(1, output.peopleCount)
+    assertEquals(0, output.poolAssignmentsCount)
+  }
+
+  @Test
+  fun `two pass collision free end to end`() {
+    val root = CompiledNode.newBuilder()
+    TextFormat.merge(
+      """
+        name: "TestRankedNode"
+        ranked_population_node {
+          pools { population_offset: 0 total_population: 300 }
+          random_seed: "two-pass-seed"
+          ranked_size: 100
+          unranked_mode: DISJOINT
+        }
+      """,
+      root,
+    )
+
+    val labeler = Labeler.build(root.build())
+    val eventCount = 100
+
+    // Pass 1: collect pool assignments.
+    val inputs = (0 until eventCount).map { i ->
+      LabelerInput.newBuilder()
+        .setEventId(
+          org.wfanet.virtualpeople.common.EventId.newBuilder()
+            .setPublisher("test")
+            .setId("event-$i")
+        )
+        .build()
+    }
+
+    inputs.forEach { input ->
+      val output = labeler.label(input, LabelingMode.POOL_IDENTITY)
+      assertEquals(1, output.poolAssignmentsCount)
+      assertEquals(0, output.poolAssignmentsCount.let { output.peopleCount })
+    }
+
+    // Pass 2: inject ranks and assign VIDs.
+    val vids = mutableSetOf<ULong>()
+    inputs.forEachIndexed { rank, input ->
+      val rankedInput =
+        input.toBuilder()
+          .addRankAssignments(
+            RankAssignment.newBuilder().setPoolOffset(0).setLocalRank(rank.toLong())
+          )
+          .build()
+
+      val output = labeler.label(rankedInput)
+      assertEquals(1, output.peopleCount)
+      val vid = output.peopleList[0].virtualPersonId.toULong()
+      assertTrue(vid < 100uL, "Ranked VID $vid should be in [0, 100)")
+      vids.add(vid)
+    }
+
+    // All ranked events must produce unique VIDs.
+    assertEquals(eventCount, vids.size, "Collision detected in two-pass flow")
+  }
 }

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -368,9 +368,7 @@ class RankedLabelingIntegrationTest {
         .build()
 
     // PopulationNode does not support pool-identity mode — should throw.
-    assertFailsWith<IllegalStateException> {
-      labeler.label(input, LabelingMode.POOL_IDENTITY)
-    }
+    assertFailsWith<IllegalStateException> { labeler.label(input, LabelingMode.POOL_IDENTITY) }
   }
 
   @Test
@@ -393,15 +391,16 @@ class RankedLabelingIntegrationTest {
     val eventCount = 100
 
     // Pass 1: collect pool assignments.
-    val inputs = (0 until eventCount).map { i ->
-      LabelerInput.newBuilder()
-        .setEventId(
-          org.wfanet.virtualpeople.common.EventId.newBuilder()
-            .setPublisher("test")
-            .setId("event-$i")
-        )
-        .build()
-    }
+    val inputs =
+      (0 until eventCount).map { i ->
+        LabelerInput.newBuilder()
+          .setEventId(
+            org.wfanet.virtualpeople.common.EventId.newBuilder()
+              .setPublisher("test")
+              .setId("event-$i")
+          )
+          .build()
+      }
 
     inputs.forEach { input ->
       val output = labeler.label(input, LabelingMode.POOL_IDENTITY)

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -15,8 +15,8 @@
 package org.wfanet.virtualpeople.core.labeler
 
 import com.google.protobuf.TextFormat
-import kotlin.test.assertFailsWith
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/model/BranchNodeImplTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/model/BranchNodeImplTest.kt
@@ -1595,4 +1595,73 @@ class BranchNodeImplTest {
     assertEquals(945, virtualPersonSizeCounts[3])
     assertEquals(765, virtualPersonSizeCounts[4])
   }
+
+  @Test
+  fun `apply multiplicity in pass-1 mode folds back pool assignments`() {
+    /**
+     * The branch node has one ranked-population-node branch and uses multiplicity to clone events.
+     * In pool-identity (pass-1) mode each clone emits a PoolAssignment instead of a virtual person.
+     * Every clone's assignment must be folded back onto the event, so the pass-1 pool-assignment
+     * total must equal the full-mode virtual-person total (one of each per clone). Regression test
+     * for applyMultiplicity previously dropping pool assignments from clones.
+     */
+    val config = compiledNode {
+      name = "TestBranchNode"
+      index = 1
+      branchNode = branchNode {
+        branches.add(
+          branch {
+            node = compiledNode {
+              rankedPopulationNode = rankedPopulationNode {
+                pools.add(
+                  virtualPersonPool {
+                    populationOffset = 100
+                    totalPopulation = 500
+                  }
+                )
+                randomSeed = "TestRankedSeed"
+                rankedSize = 200
+                unrankedMode = RankedPopulationNode.UnrankedMode.DISJOINT
+              }
+            }
+            chance = 1.0
+          }
+        )
+        randomSeed = "TestBranchNodeSeed"
+        multiplicity = multiplicity {
+          expectedMultiplicity = 3.0
+          maxValue = 1.2
+          capAtMax = true
+          personIndexField = "multiplicity_person_index"
+          randomSeed = "test multiplicity"
+        }
+      }
+    }
+    val node = ModelNode.build(config)
+
+    /**
+     * cloneCount depends only on actingFingerprint, so it is identical across both modes. Full mode
+     * yields one virtual person per clone; pass-1 mode must yield one pool assignment per clone.
+     */
+    var fullModeTotal = 0
+    var pass1Total = 0
+    (0 until FINGERPRINT_NUMBER).forEach {
+      val fullInput = labelerEvent { actingFingerprint = it }.toBuilder()
+      node.apply(fullInput)
+      fullModeTotal += fullInput.virtualPersonActivitiesCount
+
+      val pass1Input =
+        labelerEvent {
+            actingFingerprint = it
+            poolIdentityMode = true
+          }
+          .toBuilder()
+      node.apply(pass1Input)
+      assertEquals(0, pass1Input.virtualPersonActivitiesCount)
+      pass1Total += pass1Input.poolAssignmentsCount
+    }
+
+    assertEquals(fullModeTotal, pass1Total)
+    assertTrue(pass1Total > FINGERPRINT_NUMBER, "Expected multiplicity to clone some events")
+  }
 }


### PR DESCRIPTION
## Summary

Add pass-1 labeling mode for the two-pass memoized VID assignment pipeline.

### Changes

**Labeler.kt:**
- `LabelingMode` enum (`FULL`, `POOL_IDENTITY`)
- Overloaded `label(input, mode)` — sets `pool_identity_mode` on event, copies `pool_assignments` to output

**RankedPopulationNodeImpl.kt:**
- Check `pool_identity_mode` at start of `apply()` — emit `PoolAssignment` and return early
- `PopulationNodeImpl` is unaffected (backward-compatible)

Depends on virtual-people-common PR #73 (`pool_identity_mode` field on `LabelerEvent`).

## Test Plan

- [ ] `bazel test //src/test/kotlin/org/wfanet/virtualpeople/core/labeler:RankedLabelingIntegrationTest`
  - Pass-1 emits pool assignment without VID
  - PopulationNode unaffected in pass-1 mode
  - Full two-pass collision-free end-to-end (100 events)