### PR TITLE
fix: RankedPopulationNode falls back to hash on non-matching rank_assignments

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,6 +37,16 @@ bazel_dep(
     repo_name = "wfa_virtual_people_common",
 )
 
+# DO_NOT_SUBMIT: pin to the open virtual-people-common PR
+# (world-federation-of-advertisers/virtual-people-common#75) that adds the
+# VirtualPersonActivity.memoized_rank_fallback field used below. Replace with
+# a normal version bump (0.8.0) once #75 merges.
+git_override(
+    module_name = "virtual-people-common",
+    remote = "https://github.com/world-federation-of-advertisers/virtual-people-common.git",
+    commit = "d8948c7cacde765e7eec4fe2561135705f3ea755",
+)
+
 # Bazel Central Registry modules.
 bazel_dep(
     name = "rules_proto",

--- a/src/main/cc/wfa/virtual_people/core/model/ranked_population_node_impl.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/ranked_population_node_impl.cc
@@ -105,13 +105,17 @@ absl::Status RankedPopulationNodeImpl::Apply(LabelerEvent& event) const {
   VirtualPersonActivity* activity = event.add_virtual_person_activities();
   uint64_t virtual_person_id;
 
-  // Look up pre-computed rank from LabelerInput.rank_assignments. A
-  // fingerprint can legitimately route through multiple subpools across
-  // impressions and therefore appear in multiple RankAssignment entries; this
-  // leaf takes the entry whose pool_offset matches its own. If no entry
-  // matches (e.g. the fingerprint overflowed this subpool in Phase 1, or this
-  // impression reached a subpool the fingerprint has no rank in), fall back to
-  // the hash path — same as if no rank assignments were provided at all.
+  // Look up pre-computed rank from LabelerInput.rank_assignments. The caller
+  // (memoized Phase-2 sink) attaches a RankAssignment for every subpool the
+  // fingerprint is currently ranked in across this (DataProvider, ModelLine);
+  // this leaf scans the list for the entry matching its own pool_offset. If
+  // none matches, fall back to the hash path — same behavior as if no rank
+  // assignments were provided at all. The primary case for this fallback is
+  // overflow: when this subpool reached ranked_size in Phase 1 and this
+  // fingerprint was one of the unranked surplus, the subpool has no rank for
+  // it (per the design's overflow-fps-fall-back-to-unranked-path contract).
+  // Also defensively covers operator scenarios like heal-rank-index after
+  // partial data loss or a model-version mismatch between Phase 0 and Phase 2.
   bool has_rank = false;
   uint64_t local_rank = 0;
   if (event.has_labeler_input()) {

--- a/src/main/cc/wfa/virtual_people/core/model/ranked_population_node_impl.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/ranked_population_node_impl.cc
@@ -105,12 +105,16 @@ absl::Status RankedPopulationNodeImpl::Apply(LabelerEvent& event) const {
   VirtualPersonActivity* activity = event.add_virtual_person_activities();
   uint64_t virtual_person_id;
 
-  // Look up pre-computed rank from LabelerInput.rank_assignments.
-  bool has_rank_assignments = false;
+  // Look up pre-computed rank from LabelerInput.rank_assignments. A
+  // fingerprint can legitimately route through multiple subpools across
+  // impressions and therefore appear in multiple RankAssignment entries; this
+  // leaf takes the entry whose pool_offset matches its own. If no entry
+  // matches (e.g. the fingerprint overflowed this subpool in Phase 1, or this
+  // impression reached a subpool the fingerprint has no rank in), fall back to
+  // the hash path — same as if no rank assignments were provided at all.
   bool has_rank = false;
   uint64_t local_rank = 0;
   if (event.has_labeler_input()) {
-    has_rank_assignments = event.labeler_input().rank_assignments_size() > 0;
     for (const auto& ra : event.labeler_input().rank_assignments()) {
       if (ra.pool_offset() == pool_offset_) {
         local_rank = ra.local_rank();
@@ -118,13 +122,6 @@ absl::Status RankedPopulationNodeImpl::Apply(LabelerEvent& event) const {
         break;
       }
     }
-  }
-
-  // Rank assignments were provided but none match this pool — caller misuse.
-  if (has_rank_assignments && !has_rank) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "RankAssignment provided but none match pool_offset=", pool_offset_,
-        "."));
   }
 
   if (has_rank && local_rank < ranked_size_) {

--- a/src/main/cc/wfa/virtual_people/core/model/ranked_population_node_impl.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/ranked_population_node_impl.cc
@@ -116,6 +116,8 @@ absl::Status RankedPopulationNodeImpl::Apply(LabelerEvent& event) const {
   // it (per the design's overflow-fps-fall-back-to-unranked-path contract).
   // Also defensively covers operator scenarios like heal-rank-index after
   // partial data loss or a model-version mismatch between Phase 0 and Phase 2.
+  bool had_rank_assignments = event.has_labeler_input() &&
+                              event.labeler_input().rank_assignments_size() > 0;
   bool has_rank = false;
   uint64_t local_rank = 0;
   if (event.has_labeler_input()) {
@@ -126,6 +128,14 @@ absl::Status RankedPopulationNodeImpl::Apply(LabelerEvent& event) const {
         break;
       }
     }
+  }
+
+  // Memoized-rank fallback signal: stamped iff the caller attempted memoization
+  // (rank_assignments non-empty) but we end up on the hash path. The consumer
+  // aggregates this into an OpenTelemetry counter to alarm on rising
+  // memoized-fallback rates per (data provider, model line, pool offset).
+  if (had_rank_assignments && !(has_rank && local_rank < ranked_size_)) {
+    activity->set_memoized_rank_fallback(true);
   }
 
   if (has_rank && local_rank < ranked_size_) {

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
@@ -60,16 +60,16 @@ private constructor(
 
     val activity = VirtualPersonActivity.newBuilder()
 
-    val rankAssignments =
-      if (event.hasLabelerInput()) event.labelerInput.rankAssignmentsList else emptyList()
-    val rankAssignment = rankAssignments.firstOrNull { it.poolOffset.toULong() == poolOffset }
-
-    if (rankAssignments.isNotEmpty() && rankAssignment == null) {
-      error(
-        "RankAssignment provided but none match pool_offset=$poolOffset. " +
-          "Available: ${rankAssignments.map { it.poolOffset }}."
-      )
-    }
+    // Look up pre-computed rank from LabelerInput.rank_assignments. A fingerprint can legitimately
+    // route through multiple subpools across impressions and therefore appear in multiple
+    // RankAssignment entries; this leaf takes the entry whose pool_offset matches its own. If no
+    // entry matches (e.g. the fingerprint overflowed this subpool in Phase 1, or this impression
+    // reached a subpool the fingerprint has no rank in), fall back to the hash path — same as if
+    // no rank assignments were provided at all.
+    val rankAssignment =
+      if (event.hasLabelerInput())
+        event.labelerInput.rankAssignmentsList.firstOrNull { it.poolOffset.toULong() == poolOffset }
+      else null
 
     val virtualPersonId =
       if (rankAssignment != null && rankAssignment.localRank.toULong() < rankedSize) {

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
@@ -60,12 +60,15 @@ private constructor(
 
     val activity = VirtualPersonActivity.newBuilder()
 
-    // Look up pre-computed rank from LabelerInput.rank_assignments. A fingerprint can legitimately
-    // route through multiple subpools across impressions and therefore appear in multiple
-    // RankAssignment entries; this leaf takes the entry whose pool_offset matches its own. If no
-    // entry matches (e.g. the fingerprint overflowed this subpool in Phase 1, or this impression
-    // reached a subpool the fingerprint has no rank in), fall back to the hash path — same as if
-    // no rank assignments were provided at all.
+    // Look up pre-computed rank from LabelerInput.rank_assignments. The caller (memoized Phase-2
+    // sink) attaches a RankAssignment for every subpool the fingerprint is currently ranked in
+    // across this (DataProvider, ModelLine); this leaf scans the list for the entry matching its
+    // own pool_offset. If none matches, fall back to the hash path — same behavior as if no rank
+    // assignments were provided at all. The primary case for this fallback is overflow: when this
+    // subpool reached ranked_size in Phase 1 and this fingerprint was one of the unranked surplus,
+    // the subpool has no rank for it (per the design's overflow-fps-fall-back-to-unranked-path
+    // contract). Also defensively covers operator scenarios like heal-rank-index after partial
+    // data loss or a model-version mismatch between Phase 0 and Phase 2.
     val rankAssignment =
       if (event.hasLabelerInput())
         event.labelerInput.rankAssignmentsList.firstOrNull { it.poolOffset.toULong() == poolOffset }

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
@@ -69,14 +69,25 @@ private constructor(
     // the subpool has no rank for it (per the design's overflow-fps-fall-back-to-unranked-path
     // contract). Also defensively covers operator scenarios like heal-rank-index after partial
     // data loss or a model-version mismatch between Phase 0 and Phase 2.
+    val hadRankAssignments =
+      event.hasLabelerInput() && event.labelerInput.rankAssignmentsList.isNotEmpty()
     val rankAssignment =
       if (event.hasLabelerInput())
         event.labelerInput.rankAssignmentsList.firstOrNull { it.poolOffset.toULong() == poolOffset }
       else null
+    val usedRankedPath = rankAssignment != null && rankAssignment.localRank.toULong() < rankedSize
+
+    // Memoized-rank fallback signal: stamped iff the caller attempted memoization
+    // (rank_assignments non-empty) but we end up on the hash path. The consumer aggregates this
+    // into an OpenTelemetry counter to alarm on rising memoized-fallback rates per
+    // (data provider, model line, pool offset).
+    if (hadRankAssignments && !usedRankedPath) {
+      activity.memoizedRankFallback = true
+    }
 
     val virtualPersonId =
-      if (rankAssignment != null && rankAssignment.localRank.toULong() < rankedSize) {
-        poolOffset + Feistel.permute(rankAssignment.localRank.toULong(), rankedSize, randomSeed)
+      if (usedRankedPath) {
+        poolOffset + Feistel.permute(rankAssignment!!.localRank.toULong(), rankedSize, randomSeed)
       } else {
         val seed = PopulationNodeHelper.computeVidSeed(randomSeed, event.actingFingerprint)
         when (unrankedMode) {

--- a/src/test/cc/wfa/virtual_people/core/model/ranked_population_node_impl_test.cc
+++ b/src/test/cc/wfa/virtual_people/core/model/ranked_population_node_impl_test.cc
@@ -422,11 +422,14 @@ TEST(RankedPopulationNodeImplTest, NoMatchingRankAssignmentFallsBackToHash) {
   ra2->set_local_rank(17);
 
   EXPECT_THAT(node->Apply(event), IsOk());
-  uint64_t vid = event.virtual_person_activities(0).virtual_person_id();
+  const auto& activity = event.virtual_person_activities(0);
+  uint64_t vid = activity.virtual_person_id();
   // Must land in the unranked sub-range [pool_offset + ranked_size,
   // pool_offset + pool_size) = [300, 600) under DISJOINT mode.
   EXPECT_GE(vid, 300);
   EXPECT_LT(vid, 600);
+  // The whole point of this path is to surface that the leaf had to hash-fall-back.
+  EXPECT_TRUE(activity.memoized_rank_fallback());
 }
 
 // The non-matching-rank_assignments path must produce the same VID as the
@@ -458,7 +461,11 @@ TEST(RankedPopulationNodeImplTest,
   event_a.set_acting_fingerprint(42);
   event_a.mutable_labeler_input();
   EXPECT_THAT(node->Apply(event_a), IsOk());
-  uint64_t vid_a = event_a.virtual_person_activities(0).virtual_person_id();
+  const auto& activity_a = event_a.virtual_person_activities(0);
+  uint64_t vid_a = activity_a.virtual_person_id();
+  // No rank_assignments at all => caller did not attempt memoization, so the
+  // fallback signal MUST NOT fire.
+  EXPECT_FALSE(activity_a.memoized_rank_fallback());
 
   // Event B: same fingerprint, rank_assignments only for other pools.
   LabelerEvent event_b;
@@ -467,7 +474,11 @@ TEST(RankedPopulationNodeImplTest,
   ra->set_pool_offset(9000);
   ra->set_local_rank(5);
   EXPECT_THAT(node->Apply(event_b), IsOk());
-  uint64_t vid_b = event_b.virtual_person_activities(0).virtual_person_id();
+  const auto& activity_b = event_b.virtual_person_activities(0);
+  uint64_t vid_b = activity_b.virtual_person_id();
+  // Non-matching assignments => caller did attempt memoization but the leaf
+  // hash-fell-back, so the signal MUST fire.
+  EXPECT_TRUE(activity_b.memoized_rank_fallback());
 
   // Both must produce the same VID — non-matching assignments behave exactly
   // like empty assignments.

--- a/src/test/cc/wfa/virtual_people/core/model/ranked_population_node_impl_test.cc
+++ b/src/test/cc/wfa/virtual_people/core/model/ranked_population_node_impl_test.cc
@@ -381,12 +381,11 @@ TEST(RankedPopulationNodeImplTest, MultipleRankAssignmentsResolvesCorrectPool) {
   EXPECT_LT(vid, 900);
 }
 
-// A fingerprint can legitimately route to multiple subpools across impressions
-// (design ÃÂ§ Cumulative rank index map). Phase-2 attaches every per-subpool rank
-// the fingerprint holds; this leaf takes its own pool_offset. If none matches
-// Ã¢ÂÂ because the fingerprint either overflowed this subpool in Phase 1 or
-// reached this subpool only on this impression and not in any previously
-// dispatched one Ã¢ÂÂ the leaf must fall back to the hash path, not fail the job.
+// When this leaf's pool_offset matches no entry in rank_assignments, the leaf
+// must fall back to the hash path instead of failing the job. The dominant
+// case is Phase-1 overflow: when this subpool reached ranked_size and this
+// fingerprint was one of the unranked surplus, the subpool has no rank for it
+// (per design § Retention Rule, overflow-fps-fall-back-to-unranked-path).
 TEST(RankedPopulationNodeImplTest, NoMatchingRankAssignmentFallsBackToHash) {
   CompiledNode config;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
@@ -405,7 +404,7 @@ TEST(RankedPopulationNodeImplTest, NoMatchingRankAssignmentFallsBackToHash) {
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<ModelNode> node,
                        ModelNode::Build(config));
 
-  // Rank assignments only carry entries for OTHER pools (9000, 99999) Ã¢ÂÂ none
+  // Rank assignments only carry entries for OTHER pools (9000, 99999) — none
   // for this leaf's pool_offset=100. This mirrors the multi-subpool case where
   // the fingerprint holds ranks in other subpools but not this one.
   LabelerEvent event;
@@ -426,12 +425,11 @@ TEST(RankedPopulationNodeImplTest, NoMatchingRankAssignmentFallsBackToHash) {
   EXPECT_LT(vid, 600);
 }
 
-// Same invariant when rank assignments are present but match neither the
-// leaf's pool_offset nor any pool in this model: the fingerprint can only have
-// been routed to subpools that aren't reachable from this leaf, so this leaf
-// must hash-fall-back. Equivalent to NoMatchingRankAssignmentFallsBackToHash;
-// kept distinct to lock in that the empty-rank_assignments behavior is
-// identical to the non-matching-rank_assignments behavior.
+// The non-matching-rank_assignments path must produce the same VID as the
+// empty-rank_assignments path — both represent the same semantic state
+// (no rank for this fingerprint in this subpool, hash-fall-back), so same
+// input must yield the same VID. Locks in that the fix didn't accidentally
+// introduce a different hash seed for the two no-rank cases.
 TEST(RankedPopulationNodeImplTest,
      NoMatchingRankAssignmentMatchesEmptyAssignmentsVid) {
   CompiledNode config;
@@ -467,7 +465,7 @@ TEST(RankedPopulationNodeImplTest,
   EXPECT_THAT(node->Apply(event_b), IsOk());
   uint64_t vid_b = event_b.virtual_person_activities(0).virtual_person_id();
 
-  // Both must produce the same VID Ã¢ÂÂ non-matching assignments behave exactly
+  // Both must produce the same VID — non-matching assignments behave exactly
   // like empty assignments.
   EXPECT_EQ(vid_a, vid_b);
 }

--- a/src/test/cc/wfa/virtual_people/core/model/ranked_population_node_impl_test.cc
+++ b/src/test/cc/wfa/virtual_people/core/model/ranked_population_node_impl_test.cc
@@ -381,7 +381,13 @@ TEST(RankedPopulationNodeImplTest, MultipleRankAssignmentsResolvesCorrectPool) {
   EXPECT_LT(vid, 900);
 }
 
-TEST(RankedPopulationNodeImplTest, RankForNonExistentPoolReturnsError) {
+// A fingerprint can legitimately route to multiple subpools across impressions
+// (design ÃÂ§ Cumulative rank index map). Phase-2 attaches every per-subpool rank
+// the fingerprint holds; this leaf takes its own pool_offset. If none matches
+// Ã¢ÂÂ because the fingerprint either overflowed this subpool in Phase 1 or
+// reached this subpool only on this impression and not in any previously
+// dispatched one Ã¢ÂÂ the leaf must fall back to the hash path, not fail the job.
+TEST(RankedPopulationNodeImplTest, NoMatchingRankAssignmentFallsBackToHash) {
   CompiledNode config;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
       R"pb(
@@ -389,7 +395,7 @@ TEST(RankedPopulationNodeImplTest, RankForNonExistentPoolReturnsError) {
         index: 1
         ranked_population_node {
           pools { population_offset: 100 total_population: 500 }
-          random_seed: "wrong-pool-seed"
+          random_seed: "overflow-fallback-seed"
           ranked_size: 200
           unranked_mode: DISJOINT
         }
@@ -399,15 +405,71 @@ TEST(RankedPopulationNodeImplTest, RankForNonExistentPoolReturnsError) {
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<ModelNode> node,
                        ModelNode::Build(config));
 
-  // Rank assignment for pool_offset=9999 doesn't match pool_offset=100.
+  // Rank assignments only carry entries for OTHER pools (9000, 99999) Ã¢ÂÂ none
+  // for this leaf's pool_offset=100. This mirrors the multi-subpool case where
+  // the fingerprint holds ranks in other subpools but not this one.
   LabelerEvent event;
   event.set_acting_fingerprint(42);
-  auto* ra = event.mutable_labeler_input()->add_rank_assignments();
-  ra->set_pool_offset(9999);
-  ra->set_local_rank(5);
+  auto* labeler_input = event.mutable_labeler_input();
+  auto* ra1 = labeler_input->add_rank_assignments();
+  ra1->set_pool_offset(9000);
+  ra1->set_local_rank(5);
+  auto* ra2 = labeler_input->add_rank_assignments();
+  ra2->set_pool_offset(99999);
+  ra2->set_local_rank(17);
 
-  EXPECT_THAT(node->Apply(event),
-              StatusIs(absl::StatusCode::kInvalidArgument, ""));
+  EXPECT_THAT(node->Apply(event), IsOk());
+  uint64_t vid = event.virtual_person_activities(0).virtual_person_id();
+  // Must land in the unranked sub-range [pool_offset + ranked_size,
+  // pool_offset + pool_size) = [300, 600) under DISJOINT mode.
+  EXPECT_GE(vid, 300);
+  EXPECT_LT(vid, 600);
+}
+
+// Same invariant when rank assignments are present but match neither the
+// leaf's pool_offset nor any pool in this model: the fingerprint can only have
+// been routed to subpools that aren't reachable from this leaf, so this leaf
+// must hash-fall-back. Equivalent to NoMatchingRankAssignmentFallsBackToHash;
+// kept distinct to lock in that the empty-rank_assignments behavior is
+// identical to the non-matching-rank_assignments behavior.
+TEST(RankedPopulationNodeImplTest,
+     NoMatchingRankAssignmentMatchesEmptyAssignmentsVid) {
+  CompiledNode config;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        name: "TestRankedNode"
+        index: 1
+        ranked_population_node {
+          pools { population_offset: 100 total_population: 500 }
+          random_seed: "overflow-fallback-seed"
+          ranked_size: 200
+          unranked_mode: DISJOINT
+        }
+      )pb",
+      &config));
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<ModelNode> node,
+                       ModelNode::Build(config));
+
+  // Event A: no rank_assignments at all.
+  LabelerEvent event_a;
+  event_a.set_acting_fingerprint(42);
+  event_a.mutable_labeler_input();
+  EXPECT_THAT(node->Apply(event_a), IsOk());
+  uint64_t vid_a = event_a.virtual_person_activities(0).virtual_person_id();
+
+  // Event B: same fingerprint, rank_assignments only for other pools.
+  LabelerEvent event_b;
+  event_b.set_acting_fingerprint(42);
+  auto* ra = event_b.mutable_labeler_input()->add_rank_assignments();
+  ra->set_pool_offset(9000);
+  ra->set_local_rank(5);
+  EXPECT_THAT(node->Apply(event_b), IsOk());
+  uint64_t vid_b = event_b.virtual_person_activities(0).virtual_person_id();
+
+  // Both must produce the same VID Ã¢ÂÂ non-matching assignments behave exactly
+  // like empty assignments.
+  EXPECT_EQ(vid_a, vid_b);
 }
 
 TEST(RankedPopulationNodeImplTest, InvalidMultiplePools) {

--- a/src/test/cc/wfa/virtual_people/core/model/ranked_population_node_impl_test.cc
+++ b/src/test/cc/wfa/virtual_people/core/model/ranked_population_node_impl_test.cc
@@ -335,11 +335,15 @@ TEST(RankedPopulationNodeImplTest, BoundaryRankEqualsRankedSizeFallsBack) {
   ra->set_local_rank(500);
 
   EXPECT_THAT(node->Apply(event), IsOk());
-  uint64_t vid = event.virtual_person_activities(0).virtual_person_id();
+  const auto& activity = event.virtual_person_activities(0);
+  uint64_t vid = activity.virtual_person_id();
   // DISJOINT unranked range: [pool_offset + ranked_size, pool_offset +
   // pool_size).
   EXPECT_GE(vid, 600);
   EXPECT_LT(vid, 1100);
+  // Caller attempted memoization (rank_assignments non-empty) but we fell back
+  // to hash because local_rank >= ranked_size — surface the signal.
+  EXPECT_TRUE(activity.memoized_rank_fallback());
 }
 
 TEST(RankedPopulationNodeImplTest, MultipleRankAssignmentsResolvesCorrectPool) {

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -242,11 +242,10 @@ class RankedLabelingIntegrationTest {
   /**
    * Regression test for world-federation-of-advertisers/cross-media-measurement#4073.
    *
-   * A fingerprint can legitimately route to multiple subpools across impressions (design §
-   * Cumulative rank index map). Phase-2 attaches every per-subpool rank the fingerprint holds; this
-   * leaf takes its own pool_offset. If none matches — because the fingerprint either overflowed
-   * this subpool in Phase 1 or reached this subpool only on this impression and not in any
-   * previously dispatched one — the leaf must fall back to the hash path, not fail the job.
+   * When this leaf's pool_offset matches no entry in rank_assignments, the leaf must fall back to
+   * the hash path instead of failing the job. The dominant case is Phase-1 overflow: when this
+   * subpool reached ranked_size and this fingerprint was one of the unranked surplus, the subpool
+   * has no rank for it (per design § Retention Rule, overflow-fps-fall-back-to-unranked-path).
    */
   @Test
   fun `rank for non-existent pool falls back to hash`() {
@@ -289,9 +288,10 @@ class RankedLabelingIntegrationTest {
   }
 
   /**
-   * The fallback when rank_assignments are present-but-non-matching must produce the same VID as
-   * when rank_assignments are empty. Both paths represent the same semantics: this fingerprint has
-   * no rank in this subpool, fall back to hash. Same input → same VID.
+   * The non-matching-rank_assignments path must produce the same VID as the empty-rank_assignments
+   * path — both represent the same semantic state (no rank for this fingerprint in this subpool,
+   * hash-fall-back), so same input must yield the same VID. Locks in that the fix didn't
+   * accidentally introduce a different hash seed for the two no-rank cases.
    */
   @Test
   fun `non-matching rank assignment produces same VID as empty rank assignments`() {

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -16,6 +16,7 @@ package org.wfanet.virtualpeople.core.labeler
 
 import com.google.protobuf.TextFormat
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -280,11 +281,14 @@ class RankedLabelingIntegrationTest {
 
     val output = labeler.label(input)
     assertEquals(1, output.peopleCount)
-    val vid = output.peopleList[0].virtualPersonId.toULong()
+    val activity = output.peopleList[0]
+    val vid = activity.virtualPersonId.toULong()
     // DISJOINT mode: VID lands in the unranked sub-range
     // [pool_offset + ranked_size, pool_offset + pool_size) = [300, 600).
     assertTrue(vid >= 300uL, "VID $vid below unranked range")
     assertTrue(vid < 600uL, "VID $vid above pool")
+    // The whole point of this path is to surface that the leaf had to hash-fall-back.
+    assertTrue(activity.memoizedRankFallback)
   }
 
   /**
@@ -316,7 +320,11 @@ class RankedLabelingIntegrationTest {
     }
 
     // Input A: no rank_assignments at all.
-    val vidA = labeler.label(baseInput).peopleList[0].virtualPersonId
+    val activityA = labeler.label(baseInput).peopleList[0]
+    val vidA = activityA.virtualPersonId
+    // No rank_assignments at all => caller did not attempt memoization, so the
+    // fallback signal MUST NOT fire.
+    assertFalse(activityA.memoizedRankFallback)
 
     // Input B: same event id, rank_assignments only for OTHER pools.
     val inputB =
@@ -326,7 +334,11 @@ class RankedLabelingIntegrationTest {
           localRank = 5
         }
       }
-    val vidB = labeler.label(inputB).peopleList[0].virtualPersonId
+    val activityB = labeler.label(inputB).peopleList[0]
+    val vidB = activityB.virtualPersonId
+    // Non-matching assignments => caller did attempt memoization but the leaf
+    // hash-fell-back, so the signal MUST fire.
+    assertTrue(activityB.memoizedRankFallback)
 
     // Both must produce the same VID — non-matching assignments behave exactly like empty.
     assertEquals(vidA, vidB)

--- a/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/virtualpeople/core/labeler/RankedLabelingIntegrationTest.kt
@@ -16,7 +16,6 @@ package org.wfanet.virtualpeople.core.labeler
 
 import com.google.protobuf.TextFormat
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -240,15 +239,24 @@ class RankedLabelingIntegrationTest {
     assertTrue(vid < 900uL, "VID $vid should be in ranked range for pool 500")
   }
 
+  /**
+   * Regression test for world-federation-of-advertisers/cross-media-measurement#4073.
+   *
+   * A fingerprint can legitimately route to multiple subpools across impressions (design §
+   * Cumulative rank index map). Phase-2 attaches every per-subpool rank the fingerprint holds; this
+   * leaf takes its own pool_offset. If none matches — because the fingerprint either overflowed
+   * this subpool in Phase 1 or reached this subpool only on this impression and not in any
+   * previously dispatched one — the leaf must fall back to the hash path, not fail the job.
+   */
   @Test
-  fun `rank for non-existent pool throws`() {
+  fun `rank for non-existent pool falls back to hash`() {
     val labeler =
       buildLabeler(
         """
       name: "TestRankedNode"
       ranked_population_node {
         pools { population_offset: 100 total_population: 500 }
-        random_seed: "wrong-pool-seed"
+        random_seed: "overflow-fallback-seed"
         ranked_size: 200
         unranked_mode: DISJOINT
       }
@@ -260,13 +268,68 @@ class RankedLabelingIntegrationTest {
         publisher = "test"
         id = "wrong-pool-event"
       }
+      // Rank assignments only carry entries for OTHER pools — none for pool_offset=100.
       rankAssignments += rankAssignment {
-        poolOffset = 9999
+        poolOffset = 9000
         localRank = 5
+      }
+      rankAssignments += rankAssignment {
+        poolOffset = 99999
+        localRank = 17
       }
     }
 
-    assertFailsWith<IllegalStateException> { labeler.label(input) }
+    val output = labeler.label(input)
+    assertEquals(1, output.peopleCount)
+    val vid = output.peopleList[0].virtualPersonId.toULong()
+    // DISJOINT mode: VID lands in the unranked sub-range
+    // [pool_offset + ranked_size, pool_offset + pool_size) = [300, 600).
+    assertTrue(vid >= 300uL, "VID $vid below unranked range")
+    assertTrue(vid < 600uL, "VID $vid above pool")
+  }
+
+  /**
+   * The fallback when rank_assignments are present-but-non-matching must produce the same VID as
+   * when rank_assignments are empty. Both paths represent the same semantics: this fingerprint has
+   * no rank in this subpool, fall back to hash. Same input → same VID.
+   */
+  @Test
+  fun `non-matching rank assignment produces same VID as empty rank assignments`() {
+    val labeler =
+      buildLabeler(
+        """
+      name: "TestRankedNode"
+      ranked_population_node {
+        pools { population_offset: 100 total_population: 500 }
+        random_seed: "overflow-fallback-seed"
+        ranked_size: 200
+        unranked_mode: DISJOINT
+      }
+    """
+      )
+
+    val baseInput = labelerInput {
+      eventId = eventId {
+        publisher = "test"
+        id = "shared-id"
+      }
+    }
+
+    // Input A: no rank_assignments at all.
+    val vidA = labeler.label(baseInput).peopleList[0].virtualPersonId
+
+    // Input B: same event id, rank_assignments only for OTHER pools.
+    val inputB =
+      baseInput.copy {
+        rankAssignments += rankAssignment {
+          poolOffset = 9000
+          localRank = 5
+        }
+      }
+    val vidB = labeler.label(inputB).peopleList[0].virtualPersonId
+
+    // Both must produce the same VID — non-matching assignments behave exactly like empty.
+    assertEquals(vidA, vidB)
   }
 
   @Test
@@ -346,7 +409,7 @@ class RankedLabelingIntegrationTest {
     assertEquals(
       0,
       output.poolAssignmentsCount,
-      "Pass-1 PopulationNode should emit no pool assignment"
+      "Pass-1 PopulationNode should emit no pool assignment",
     )
   }
 


### PR DESCRIPTION
When this leaf's `pool_offset` matches no entry in `LabelerInput.rank_assignments`, the leaf must fall back to the hash path instead of failing the job. The dominant case is Phase-1 overflow: when this subpool reached `ranked_size` and this fingerprint was one of the unranked surplus, the subpool has no rank for it — the design (§ Retention Rule, line 278) explicitly requires "overflow fps are not ranked and fall back to the unranked path at Phase 2."

The labeler tree is deterministic, so each impression routes to exactly one subpool leaf. The `rank_assignments` list can hold multiple entries only because the memoized Phase-2 sink conservatively attaches a `RankAssignment` for every subpool the fingerprint is currently ranked in across this `(DataProvider, ModelLine)`; the leaf then picks its own. Today the leaf throws `InvalidArgument` whenever none matches — failing the whole `VidLabelingJob` on every overflowed fingerprint. This PR aligns the code with the proto KDoc on `LabelerInput.RankAssignment`, which already specifies: "If no RankAssignment matches, the event gets hash-based VID assignment."

In the same PR, also stamps `VirtualPersonActivity.memoized_rank_fallback` (new in [virtual-people-common#75](https://github.com/world-federation-of-advertisers/virtual-people-common/pull/75)) whenever the leaf takes the hash path despite a non-empty `rank_assignments`. Without this signal, the memoized Phase-2 pipeline silently degrades to hash-based VID assignment when subpools saturate, with no operational visibility. The consumer (`VidLabelingSink` in [cross-media-measurement#4072](https://github.com/world-federation-of-advertisers/cross-media-measurement/pull/4072)) aggregates this per `(data provider, model line)` into an OpenTelemetry counter to alarm on a rising fallback rate — the indicator that a subpool's `ranked_size` should be raised.

C++ and Kotlin implementations updated symmetrically. Tests cover all four cases: ranked path (no fallback), no `rank_assignments` (no fallback, no memoization attempted), non-matching `rank_assignments` (fallback set), matching with `local_rank >= ranked_size` (fallback set). Full repo test sweep passes (45/45).

Depends on `virtual-people-common` 0.8.0 (adds `VirtualPersonActivity.memoized_rank_fallback`), which has landed in the WFA Bazel registry; `MODULE.bazel` now pins that release instead of a `git_override`.

Issue: world-federation-of-advertisers/cross-media-measurement#4073
