### PR TITLE
feat: set memoized_rank_fallback when ranked path is bypassed

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,6 +37,16 @@ bazel_dep(
     repo_name = "wfa_virtual_people_common",
 )
 
+# DO_NOT_SUBMIT: pin to the open virtual-people-common PR
+# (world-federation-of-advertisers/virtual-people-common#75) that adds the
+# VirtualPersonActivity.memoized_rank_fallback field used below. Replace with
+# a normal version bump (0.8.0) once #75 merges.
+git_override(
+    module_name = "virtual-people-common",
+    remote = "https://github.com/world-federation-of-advertisers/virtual-people-common.git",
+    commit = "d8948c7cacde765e7eec4fe2561135705f3ea755",
+)
+
 # Bazel Central Registry modules.
 bazel_dep(
     name = "rules_proto",

--- a/src/main/cc/wfa/virtual_people/core/model/ranked_population_node_impl.cc
+++ b/src/main/cc/wfa/virtual_people/core/model/ranked_population_node_impl.cc
@@ -116,6 +116,9 @@ absl::Status RankedPopulationNodeImpl::Apply(LabelerEvent& event) const {
   // it (per the design's overflow-fps-fall-back-to-unranked-path contract).
   // Also defensively covers operator scenarios like heal-rank-index after
   // partial data loss or a model-version mismatch between Phase 0 and Phase 2.
+  bool had_rank_assignments =
+      event.has_labeler_input() &&
+      event.labeler_input().rank_assignments_size() > 0;
   bool has_rank = false;
   uint64_t local_rank = 0;
   if (event.has_labeler_input()) {
@@ -126,6 +129,14 @@ absl::Status RankedPopulationNodeImpl::Apply(LabelerEvent& event) const {
         break;
       }
     }
+  }
+
+  // Memoized-rank fallback signal: stamped iff the caller attempted memoization
+  // (rank_assignments non-empty) but we end up on the hash path. The consumer
+  // aggregates this into an OpenTelemetry counter to alarm on rising
+  // memoized-fallback rates per (data provider, model line, pool offset).
+  if (had_rank_assignments && !(has_rank && local_rank < ranked_size_)) {
+    activity->set_memoized_rank_fallback(true);
   }
 
   if (has_rank && local_rank < ranked_size_) {

--- a/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
+++ b/src/main/kotlin/org/wfanet/virtualpeople/core/model/RankedPopulationNodeImpl.kt
@@ -69,14 +69,25 @@ private constructor(
     // the subpool has no rank for it (per the design's overflow-fps-fall-back-to-unranked-path
     // contract). Also defensively covers operator scenarios like heal-rank-index after partial
     // data loss or a model-version mismatch between Phase 0 and Phase 2.
+    val hadRankAssignments =
+      event.hasLabelerInput() && event.labelerInput.rankAssignmentsList.isNotEmpty()
     val rankAssignment =
       if (event.hasLabelerInput())
         event.labelerInput.rankAssignmentsList.firstOrNull { it.poolOffset.toULong() == poolOffset }
       else null
+    val usedRankedPath = rankAssignment != null && rankAssignment.localRank.toULong() < rankedSize
+
+    // Memoized-rank fallback signal: stamped iff the caller attempted memoization
+    // (rank_assignments non-empty) but we end up on the hash path. The consumer aggregates this
+    // into an OpenTelemetry counter to alarm on rising memoized-fallback rates per
+    // (data provider, model line, pool offset).
+    if (hadRankAssignments && !usedRankedPath) {
+      activity.memoizedRankFallback = true
+    }
 
     val virtualPersonId =
-      if (rankAssignment != null && rankAssignment.localRank.toULong() < rankedSize) {
-        poolOffset + Feistel.permute(rankAssignment.localRank.toULong(), rankedSize, randomSeed)
+      if (usedRankedPath) {
+        poolOffset + Feistel.permute(rankAssignment!!.localRank.toULong(), rankedSize, randomSeed)
       } else {
         val seed = PopulationNodeHelper.computeVidSeed(randomSeed, event.actingFingerprint)
         when (unrankedMode) {

--- a/src/test/cc/wfa/virtual_people/core/model/ranked_population_node_impl_test.cc
+++ b/src/test/cc/wfa/virtual_people/core/model/ranked_population_node_impl_test.cc
@@ -335,11 +335,15 @@ TEST(RankedPopulationNodeImplTest, BoundaryRankEqualsRankedSizeFallsBack) {
   ra->set_local_rank(500);
 
   EXPECT_THAT(node->Apply(event), IsOk());
-  uint64_t vid = event.virtual_person_activities(0).virtual_person_id();
+  const auto& activity = event.virtual_person_activities(0);
+  uint64_t vid = activity.virtual_person_id();
   // DISJOINT unranked range: [pool_offset + ranked_size, pool_offset +
   // pool_size).
   EXPECT_GE(vid, 600);
   EXPECT_LT(vid, 1100);
+  // Caller attempted memoization (rank_assignments non-empty) but we fell back
+  // to hash because local_rank >= ranked_size — surface the signal.
+  EXPECT_TRUE(activity.memoized_rank_fallback());
 }
 
 TEST(RankedPopulationNodeImplTest, MultipleRankAssignmentsResolvesCorrectPool) {


### PR DESCRIPTION
Stamps `VirtualPersonActivity.memoized_rank_fallback` (new in [virtual-people-common#75](https://github.com/world-federation-of-advertisers/virtual-people-common/pull/75)) when the caller attempted memoization (`LabelerInput.rank_assignments` non-empty) but the leaf had to fall back to the hash path. The dominant cause is Phase-1 overflow: the subpool reached `ranked_size` and this fingerprint was one of the unranked surplus.

Without this signal, the memoized Phase-2 pipeline silently degrades to hash-based VID assignment when subpools saturate. The consumer (`VidLabelingSink` in [cross-media-measurement#4072](https://github.com/world-federation-of-advertisers/cross-media-measurement/pull/4072)) aggregates this per `(data provider, model line, pool offset)` into an OpenTelemetry counter to alarm on rising fallback rates — the indicator that a subpool's `ranked_size` should be raised.

The field stays `false` on two cases that share the hash path:
- No `rank_assignments` provided (caller did not attempt memoization).
- Matching `rank_assignments` with `local_rank` in range (ranked path taken).

C++ and Kotlin tests assert the field across all four cases (ranked path, no `rank_assignments`, non-matching `rank_assignments`, matching but `local_rank >= ranked_size`).

⚠️ **DO_NOT_SUBMIT**: `MODULE.bazel` currently pins `virtual-people-common` via `git_override` to the open PR #75; replace with a normal version bump once #75 lands.

Stacked on #89 (the bug fix that introduced the hash fallback).

Related: world-federation-of-advertisers/cross-media-measurement#4073
